### PR TITLE
[feat] 카테고리에 해당하는 모임 조회 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -46,5 +47,11 @@ public class MoimController {
     public ApiResponseDto<SubmittedMoimResponse> getSubmittedMoimDetail(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.SUBMITTED_MOIM_DETAIL_GET_SUCCESS,
                 moimQueryService.getSubmittedMoimDetail(moimId));
+    }
+
+    @GetMapping("/v1/moim-list")
+    public ApiResponseDto getMoimListByCategory(@RequestParam String category) {
+        return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_CATEGORY_GET_SUCCESS,
+                moimQueryService.getMoimListByCategory(category));
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -44,7 +44,7 @@ public class Moim extends BaseTimeEntity {
     private Host host;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    private CategoryInfo category;
+    private CategoryInfo categoryList;
 
     private boolean isOffline;
 
@@ -82,7 +82,7 @@ public class Moim extends BaseTimeEntity {
     @Builder
     public Moim(
             final Host host,
-            final CategoryInfo category,
+            final CategoryInfo categoryList,
             final boolean isOffline,
             final String spot,
             final DateInfo dateList,
@@ -96,7 +96,7 @@ public class Moim extends BaseTimeEntity {
             final MoimState moimState
     ) {
         this.host = host;
-        this.category = category;
+        this.categoryList = categoryList;
         this.isOffline = isOffline;
         this.spot = spot;
         this.dateList = dateList;

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimByCategoryResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimByCategoryResponse.java
@@ -1,0 +1,16 @@
+package com.pickple.server.api.moim.dto.response;
+
+import com.pickple.server.api.moim.domain.DateInfo;
+import lombok.Builder;
+
+@Builder
+public record MoimByCategoryResponse(
+        Long moimId,
+        int dayOfDay,
+        String title,
+        String hostNickName,
+        DateInfo dateList,
+        String moimImageUrl,
+        String hostImageUrl
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -3,8 +3,11 @@ package com.pickple.server.api.moim.repository;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MoimRepository extends JpaRepository<Moim, Long> {
     Optional<Moim> findMoimById(Long id);
@@ -13,4 +16,10 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
         return findMoimById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_NOT_FOUND));
     }
+
+    @Query(value = "SELECT * FROM moims WHERE EXISTS (" +
+            "SELECT 1 FROM jsonb_each_text(category_list) AS categories " +
+            "WHERE categories.value = :category)",
+            nativeQuery = true)
+    List<Moim> findMoimListByCategory(@Param("category") String category);
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -22,7 +22,7 @@ public class MoimCommandService {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
         Moim moim = Moim.builder()
                 .host(host)
-                .category(request.categoryList())
+                .categoryList(request.categoryList())
                 .isOffline(request.isOffline())
                 .spot(request.spot())
                 .dateList(request.dateList())

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -1,10 +1,13 @@
 package com.pickple.server.api.moim.service;
 
 import com.pickple.server.api.moim.domain.Moim;
+import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.dto.response.SubmittedMoimResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.global.util.DateUtil;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,5 +46,20 @@ public class MoimQueryService {
                 .hostImageUrl(moim.getHost().getImageUrl())
                 .moimImageUrl(moim.getImageList().getImageUrl1())
                 .build();
+    }
+
+    public List<MoimByCategoryResponse> getMoimListByCategory(final String category) {
+        List<Moim> moimList = moimRepository.findMoimListByCategory(category);
+        return moimList.stream()
+                .map(oneMoim -> MoimByCategoryResponse.builder()
+                        .moimId(oneMoim.getId())
+                        .dayOfDay(DateUtil.calculateDayOfDay(oneMoim.getDateList().getDate()))
+                        .title(oneMoim.getTitle())
+                        .hostNickName(oneMoim.getHost().getNickname())
+                        .dateList(oneMoim.getDateList())
+                        .moimImageUrl(oneMoim.getImageList().getImageUrl1())
+                        .hostImageUrl(oneMoim.getHost().getImageUrl())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
     MOIM_SUBMISSION_POST_SUCCESS(20007, HttpStatus.OK, "모임 참여 신청 성공"),
     PRESIGNED_URL_GET_SUCCESS(20008, HttpStatus.OK, "presigned url 발급 성공"),
     SUBMITTED_MOIM_DETAIL_GET_SUCCESS(20008, HttpStatus.OK, "신청한 모임 상세 정보 조회 성공"),
+    MOIM_LIST_BY_CATEGORY_GET_SUCCESS(20010, HttpStatus.OK, "카테고리에 해당하는 모임 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #39  

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 카테고리에 해당하는 모임 조회 API 구현
  - 카테고리별 모임 리스트를 조회하는 과정에서 nativeQuery를 사용했습니다.
  - JPQL만으로는 JSONB 형식에 대한 처리를 할 수 없기 때문에 사용했는데, 이 부분은 추후 아티클로 정리해서 올리겠습니다.
  - 추가적인 부분으로, 파라미터 타입을 String이 아니라 enum 타입으로 넘겨주는 것에 대한 리팩토링을 고민해봐야할 것 같습니다.
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 멍청한짓그만하겠습니다. (그럴수만있다면..........)

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="679" alt="스크린샷 2024-07-12 오후 6 28 52" src="https://github.com/user-attachments/assets/91b0a4ca-240f-4267-8f7b-ab2929bb4a0c">
