### PR TITLE
[feat] 모임에 해당하는 공지사항 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -2,9 +2,11 @@ package com.pickple.server.api.notice.controller;
 
 import com.pickple.server.api.notice.dto.request.NoticeCreateRequest;
 import com.pickple.server.api.notice.service.NoticeCommandService;
+import com.pickple.server.api.notice.service.NoticeQueryService;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,11 +19,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class NoticeController {
 
     private final NoticeCommandService noticeCommandService;
+    private final NoticeQueryService noticeQueryService;
 
     @PostMapping("/v1/moim/{moimId}/notice")
     public ApiResponseDto createNotice(@PathVariable Long moimId,
                                        @RequestBody NoticeCreateRequest noticeCreateRequest) {
         noticeCommandService.createNotice(moimId, noticeCreateRequest);
-        return ApiResponseDto.success(SuccessCode.HOST_POST_SUCCESS);
+        return ApiResponseDto.success(SuccessCode.NOTICE_POST_SUCCESS);
+    }
+
+    @GetMapping("/v1/moim/{moimId}/noitce-list")
+    public ApiResponseDto getNoticeListByMoimId(@PathVariable Long moimId) {
+        return ApiResponseDto.success(SuccessCode.NOTICE_LIST_GET_SUCCESS,
+                noticeQueryService.getNoticeListByMoimId(moimId));
     }
 }

--- a/src/main/java/com/pickple/server/api/notice/domain/Notice.java
+++ b/src/main/java/com/pickple/server/api/notice/domain/Notice.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.notice.domain;
 
 import com.pickple.server.api.moim.domain.Moim;
+import com.pickple.server.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notice {
+public class Notice extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
@@ -1,0 +1,16 @@
+package com.pickple.server.api.notice.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeListGetByMoimResponse(
+        Long noticeId,   //공지사항id
+        String hostNickName,   //호스트 닉네임
+        String hostImageUrl,   //	호스트 이미지
+        String title,    //공지사항 제목
+        String content,    //공지사항 내용
+        String date,    //공지사항 등록 일자 및 시간 yyyy.mm.dd hh:mm:ss
+        String noticeImageUrl, //공지사항 이미지
+        Long hostId//	호스트 id
+) {
+}

--- a/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
@@ -4,13 +4,13 @@ import lombok.Builder;
 
 @Builder
 public record NoticeListGetByMoimResponse(
-        Long noticeId,   //공지사항id
-        String hostNickName,   //호스트 닉네임
-        String hostImageUrl,   //	호스트 이미지
-        String title,    //공지사항 제목
-        String content,    //공지사항 내용
-        String date,    //공지사항 등록 일자 및 시간 yyyy.mm.dd hh:mm:ss
-        String noticeImageUrl, //공지사항 이미지
-        Long hostId//	호스트 id
+        Long noticeId,          //공지사항id
+        String hostNickName,    //호스트 닉네임
+        String hostImageUrl,    //호스트 이미지
+        String title,           //공지사항 제목
+        String content,         //공지사항 내용
+        String date,            //공지사항 등록 일자 및 시간 yyyy.mm.dd hh:mm:ss
+        String noticeImageUrl,  //공지사항 이미지
+        Long hostId             //호스트 id
 ) {
 }

--- a/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
@@ -1,7 +1,10 @@
 package com.pickple.server.api.notice.repository;
 
 import com.pickple.server.api.notice.domain.Notice;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findNoticeByMoimId(Long moimId);
 }

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -1,0 +1,40 @@
+package com.pickple.server.api.notice.service;
+
+import com.pickple.server.api.moim.domain.Moim;
+import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.api.notice.domain.Notice;
+import com.pickple.server.api.notice.dto.response.NoticeListGetByMoimResponse;
+import com.pickple.server.api.notice.repository.NoticeRepository;
+import com.pickple.server.global.util.DateTimeUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeQueryService {
+
+    private final MoimRepository moimRepository;
+    private final NoticeRepository noticeRepository;
+
+    public List<NoticeListGetByMoimResponse> getNoticeListByMoimId(Long moimId) {
+        Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
+        List<Notice> noticeList = noticeRepository.findNoticeByMoimId(moimId);
+
+        return noticeList.stream()
+                .map(oneNotice -> NoticeListGetByMoimResponse.builder()
+                        .noticeId(oneNotice.getId())
+                        .hostNickName(moim.getHost().getNickname())
+                        .hostImageUrl(moim.getHost().getImageUrl())
+                        .title(oneNotice.getTitle())
+                        .content(oneNotice.getContent())
+                        .date(DateTimeUtil.refineTime(oneNotice.getCreatedAt()))
+                        .noticeImageUrl(oneNotice.getImageUrl())
+                        .hostId(moim.getHost().getId())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -31,7 +31,7 @@ public class NoticeQueryService {
                         .hostImageUrl(moim.getHost().getImageUrl())
                         .title(oneNotice.getTitle())
                         .content(oneNotice.getContent())
-                        .date(DateTimeUtil.refineTime(oneNotice.getCreatedAt()))
+                        .date(DateTimeUtil.refineDateAndTime(oneNotice.getCreatedAt()))
                         .noticeImageUrl(oneNotice.getImageUrl())
                         .hostId(moim.getHost().getId())
                         .build())

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -20,7 +20,8 @@ public enum SuccessCode {
     MOIM_SUBMISSION_POST_SUCCESS(20007, HttpStatus.OK, "모임 참여 신청 성공"),
     PRESIGNED_URL_GET_SUCCESS(20008, HttpStatus.OK, "presigned url 발급 성공"),
     SUBMITTED_MOIM_DETAIL_GET_SUCCESS(20008, HttpStatus.OK, "신청한 모임 상세 정보 조회 성공"),
-    HOST_POST_SUCCESS(20009, HttpStatus.OK, "공지사항 작성 성공"),
+    NOTICE_POST_SUCCESS(20009, HttpStatus.OK, "공지사항 작성 성공"),
+    NOTICE_LIST_GET_SUCCESS(20011, HttpStatus.OK, "공지사항 리스트 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");

--- a/src/main/java/com/pickple/server/global/util/DateTimeUtil.java
+++ b/src/main/java/com/pickple/server/global/util/DateTimeUtil.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class DateTimeUtil {
-    public static String refineTime(LocalDateTime localDateTime) {
+    public static String refineDateAndTime(LocalDateTime localDateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
         return localDateTime.format(formatter);
     }

--- a/src/main/java/com/pickple/server/global/util/DateTimeUtil.java
+++ b/src/main/java/com/pickple/server/global/util/DateTimeUtil.java
@@ -1,0 +1,13 @@
+package com.pickple.server.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DateTimeUtil {
+    public static String refineTime(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
+        return localDateTime.format(formatter);
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #42 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
모임에 해당하는 공지사항 전체 조회 api를 구현했습니다.
날짜를 보내드릴 때 포맷을 위해 dataTimeUtil클래스에 refineDateAndTime 메소드를 구현했습니다.
notice 엔티티에 baseTimeEntity 상속이 안되어있어서 상속을 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1033" alt="스크린샷 2024-07-12 오후 7 30 07" src="https://github.com/user-attachments/assets/07f5bc3f-1d9a-459f-aea0-592a209267db">
