### PR TITLE
[feat] 홈 배너 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -66,4 +66,10 @@ public class MoimController {
         return ApiResponseDto.success(SuccessCode.MOIM_QUESTION_LIST_GET_SUCCESS,
                 moimQueryService.getMoimQuestionList(moimId));
     }
+
+    @GetMapping("/v1/moim/banner")
+    private ApiResponseDto getMoimBanner() {
+        return ApiResponseDto.success(SuccessCode.MOIM_BANNER_GET_SUCCESS,
+                moimQueryService.getMoimBanner());
+    }
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -78,4 +78,14 @@ public class MoimQueryService {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
         return moim.getQuestionList();
     }
+
+    public Long getMoimBanner() {
+        List<Long> moimIdList = moimRepository.findAll()
+                .stream()
+                .map(Moim::getId)
+                .toList();
+
+        int randomIndex = random.nextInt(moimIdList.size());
+        return moimIdList.get(randomIndex);
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #51 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
홈 배너 조회 api를 구현합니다.
랜덤함수를 이용하여 id가 랜덤으로 노출되도록 구현했습니다

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
브랜치 잘 파서 작업하겠습니다..데둉..

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-07-13 오전 1 01 51" src="https://github.com/user-attachments/assets/064d3464-45e4-4090-b379-db4f743b6328">
<img width="1470" alt="스크린샷 2024-07-13 오전 1 02 18" src="https://github.com/user-attachments/assets/d3609c67-d1ed-40ae-a0f8-87085be1baa0">

