### PR TITLE
[feat] 게스트에 해당하는 신청한 모임 조회 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -3,9 +3,9 @@ package com.pickple.server.api.moim.controller;
 import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
-import com.pickple.server.api.moim.dto.response.SubmittedMoimResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
+import com.pickple.server.api.moimsubmission.dto.response.MoimSubmitResponse;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
@@ -44,7 +44,7 @@ public class MoimController {
     }
 
     @GetMapping("/v1/submitted-moim/{moimId}")
-    public ApiResponseDto<SubmittedMoimResponse> getSubmittedMoimDetail(@PathVariable Long moimId) {
+    public ApiResponseDto<MoimSubmitResponse> getSubmittedMoimDetail(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.SUBMITTED_MOIM_DETAIL_GET_SUCCESS,
                 moimQueryService.getSubmittedMoimDetail(moimId));
     }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -5,7 +5,7 @@ import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
-import com.pickple.server.api.moimsubmission.dto.response.MoimSubmitResponse;
+import com.pickple.server.api.moimsubmission.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
@@ -44,7 +44,7 @@ public class MoimController {
     }
 
     @GetMapping("/v1/submitted-moim/{moimId}")
-    public ApiResponseDto<MoimSubmitResponse> getSubmittedMoimDetail(@PathVariable Long moimId) {
+    public ApiResponseDto<SubmittedMoimByGuestResponse> getSubmittedMoimDetail(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.SUBMITTED_MOIM_DETAIL_GET_SUCCESS,
                 moimQueryService.getSubmittedMoimDetail(moimId));
     }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/SubmittedMoimByGuestResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/SubmittedMoimByGuestResponse.java
@@ -1,0 +1,17 @@
+package com.pickple.server.api.moim.dto.response;
+
+import com.pickple.server.api.moim.domain.DateInfo;
+import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
+import lombok.Builder;
+
+@Builder
+public record SubmittedMoimByGuestResponse(
+        Long moimId,
+        MoimSubmissionState moimSubmissionState,
+        String title,
+        String hostNickname,
+        DateInfo dateList,
+        int fee,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -5,8 +5,8 @@ import com.pickple.server.api.moim.domain.QuestionInfo;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
-import com.pickple.server.api.moim.dto.response.SubmittedMoimResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.api.moimsubmission.dto.response.MoimSubmitResponse;
 import com.pickple.server.global.util.DateUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,9 +36,9 @@ public class MoimQueryService {
                 .build();
     }
 
-    public SubmittedMoimResponse getSubmittedMoimDetail(final Long moimId) {
+    public MoimSubmitResponse getSubmittedMoimDetail(final Long moimId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
-        return SubmittedMoimResponse.builder()
+        return MoimSubmitResponse.builder()
                 .title(moim.getTitle())
                 .hostNickname(moim.getHost().getNickname())
                 .isOffline(moim.isOffline())

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -6,7 +6,7 @@ import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
-import com.pickple.server.api.moimsubmission.dto.response.MoimSubmitResponse;
+import com.pickple.server.api.moimsubmission.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.global.util.DateUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,9 +36,9 @@ public class MoimQueryService {
                 .build();
     }
 
-    public MoimSubmitResponse getSubmittedMoimDetail(final Long moimId) {
+    public SubmittedMoimByGuestResponse getSubmittedMoimDetail(final Long moimId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
-        return MoimSubmitResponse.builder()
+        return SubmittedMoimByGuestResponse.builder()
                 .title(moim.getTitle())
                 .hostNickname(moim.getHost().getNickname())
                 .isOffline(moim.isOffline())

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -1,15 +1,19 @@
 package com.pickple.server.api.moimsubmission.controller;
 
+import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
 import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitRequest;
 import com.pickple.server.api.moimsubmission.service.MoimSubmissionCommandService;
+import com.pickple.server.api.moimsubmission.service.MoimSubmissionQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MoimSubmissionController {
 
     private final MoimSubmissionCommandService moimSubmissionCommandService;
+    private final MoimSubmissionQueryService moimSubmissionQueryService;
 
     @PostMapping("/v1/moim/{moimId}")
     public ApiResponseDto createMoimSubmission(
@@ -27,5 +32,14 @@ public class MoimSubmissionController {
     ) {
         moimSubmissionCommandService.createMoimSubmission(moimId, guestId, moimSubmitRequest);
         return ApiResponseDto.success(SuccessCode.MOIM_SUBMISSION_POST_SUCCESS);
+    }
+
+    @GetMapping("/v1/guest/{guestId}/submitted-moim-list")
+    public ApiResponseDto getSubmittedMoimListByGuest(
+            @PathVariable Long guestId,
+            @RequestParam MoimSubmissionState moimSubmissionState
+    ) {
+        return ApiResponseDto.success(SuccessCode.SUBMITTED_MOIM_LIST_BY_GUEST_GET_SUCCESS,
+                moimSubmissionQueryService.getSubmittedMoimListByGuest(guestId, moimSubmissionState));
     }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmitResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmitResponse.java
@@ -1,10 +1,10 @@
-package com.pickple.server.api.moim.dto.response;
+package com.pickple.server.api.moimsubmission.dto.response;
 
 import com.pickple.server.api.moim.domain.DateInfo;
 import lombok.Builder;
 
 @Builder
-public record SubmittedMoimResponse(
+public record MoimSubmitResponse(
         String title,
         String hostNickname,
         boolean isOffline,

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/SubmittedMoimByGuestResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/SubmittedMoimByGuestResponse.java
@@ -4,7 +4,7 @@ import com.pickple.server.api.moim.domain.DateInfo;
 import lombok.Builder;
 
 @Builder
-public record MoimSubmitResponse(
+public record SubmittedMoimByGuestResponse(
         String title,
         String hostNickname,
         boolean isOffline,

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -3,8 +3,13 @@ package com.pickple.server.api.moimsubmission.repository;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, Long> {
     boolean existsByMoimAndMoimSubmissionState(Moim moim, MoimSubmissionState moimSubmissionState);
+
+    List<MoimSubmission> findAllByGuestId(Long guestId);
+
+    List<MoimSubmission> findAllByMoimSubmissionState(MoimSubmissionState moimSubmissionState);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -1,0 +1,55 @@
+package com.pickple.server.api.moimsubmission.service;
+
+import com.pickple.server.api.guest.domain.Guest;
+import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
+import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
+import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
+import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MoimSubmissionQueryService {
+
+    private final GuestRepository guestRepository;
+    private final MoimSubmissionRepository moimSubmissionRepository;
+
+    public List<SubmittedMoimByGuestResponse> getSubmittedMoimListByGuest(final Long guestId,
+                                                                          final MoimSubmissionState moimSubmissionState) {
+        Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
+        if (moimSubmissionState.equals(MoimSubmissionState.ALL)) {
+            List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllByGuestId(guest.getId());
+            return moimSubmissionList.stream()
+                    .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
+                            .moimId(oneMoimSubmission.getMoim().getId())
+                            .moimSubmissionState(oneMoimSubmission.getMoimSubmissionState())
+                            .title(oneMoimSubmission.getMoim().getTitle())
+                            .hostNickname(oneMoimSubmission.getMoim().getHost().getNickname())
+                            .dateList(oneMoimSubmission.getMoim().getDateList())
+                            .fee(oneMoimSubmission.getMoim().getFee())
+                            .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
+                            .build()
+                    ).collect(Collectors.toList());
+        } else {
+            List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllByMoimSubmissionState(
+                    moimSubmissionState);
+            return moimSubmissionList.stream()
+                    .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
+                            .moimId(oneMoimSubmission.getMoim().getId())
+                            .moimSubmissionState(oneMoimSubmission.getMoimSubmissionState())
+                            .title(oneMoimSubmission.getMoim().getTitle())
+                            .hostNickname(oneMoimSubmission.getMoim().getHost().getNickname())
+                            .dateList(oneMoimSubmission.getMoim().getDateList())
+                            .fee(oneMoimSubmission.getMoim().getFee())
+                            .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
+                            .build()
+                    ).collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -6,6 +6,8 @@ import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,33 +25,28 @@ public class MoimSubmissionQueryService {
     public List<SubmittedMoimByGuestResponse> getSubmittedMoimListByGuest(final Long guestId,
                                                                           final MoimSubmissionState moimSubmissionState) {
         Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
+        List<MoimSubmission> moimSubmissionList;
+
         if (moimSubmissionState.equals(MoimSubmissionState.ALL)) {
-            List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllByGuestId(guest.getId());
-            return moimSubmissionList.stream()
-                    .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
-                            .moimId(oneMoimSubmission.getMoim().getId())
-                            .moimSubmissionState(oneMoimSubmission.getMoimSubmissionState())
-                            .title(oneMoimSubmission.getMoim().getTitle())
-                            .hostNickname(oneMoimSubmission.getMoim().getHost().getNickname())
-                            .dateList(oneMoimSubmission.getMoim().getDateList())
-                            .fee(oneMoimSubmission.getMoim().getFee())
-                            .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
-                            .build()
-                    ).collect(Collectors.toList());
+            moimSubmissionList = moimSubmissionRepository.findAllByGuestId(guest.getId());
         } else {
-            List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllByMoimSubmissionState(
-                    moimSubmissionState);
-            return moimSubmissionList.stream()
-                    .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
-                            .moimId(oneMoimSubmission.getMoim().getId())
-                            .moimSubmissionState(oneMoimSubmission.getMoimSubmissionState())
-                            .title(oneMoimSubmission.getMoim().getTitle())
-                            .hostNickname(oneMoimSubmission.getMoim().getHost().getNickname())
-                            .dateList(oneMoimSubmission.getMoim().getDateList())
-                            .fee(oneMoimSubmission.getMoim().getFee())
-                            .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
-                            .build()
-                    ).collect(Collectors.toList());
+            moimSubmissionList = moimSubmissionRepository.findAllByMoimSubmissionState(moimSubmissionState);
         }
+
+        if (moimSubmissionList.isEmpty()) {
+            throw new CustomException(ErrorCode.MOIM_BY_STATE_NOT_FOUND);
+        }
+
+        return moimSubmissionList.stream()
+                .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
+                        .moimId(oneMoimSubmission.getMoim().getId())
+                        .moimSubmissionState(oneMoimSubmission.getMoimSubmissionState())
+                        .title(oneMoimSubmission.getMoim().getTitle())
+                        .hostNickname(oneMoimSubmission.getMoim().getHost().getNickname())
+                        .dateList(oneMoimSubmission.getMoim().getDateList())
+                        .fee(oneMoimSubmission.getMoim().getFee())
+                        .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     GUEST_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "존재하지 않는 게스트입니다"),
     MOIM_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     HOST_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다"),
-
+    MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
     // Method Not Allowed Error 405
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),
 

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -25,6 +25,7 @@ public enum SuccessCode {
     NOTICE_LIST_GET_SUCCESS(20011, HttpStatus.OK, "공지사항 리스트 조회 성공"),
     MOIM_DESCRIPTION_GET_SUCCESS(20012, HttpStatus.OK, "모임에 해당하는 소개 조회 성공"),
     MOIM_QUESTION_LIST_GET_SUCCESS(20013, HttpStatus.OK, "모임 질문 목록 조회 성공"),
+    SUBMITTED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20014, HttpStatus.OK, "게스트에 해당하는 신청한 모임 리스트 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #49 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게스트에 해당하는 신청한 모임 조회 API 구현
  - 모임 신청 상태에 대한 필터링을 전체 / 그 이외 상태로 분기처리 하여 조회했습니다.
  - 신청한 모임이 없을 때 (빈 배열일때)에 대한 예외 처리를 진행했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 추후에 쿼리문 활용하여 리팩토링 진행하겠습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 전체 조회
<img width="678" alt="스크린샷 2024-07-13 오전 1 28 11" src="https://github.com/user-attachments/assets/1b5ed2eb-58e2-466c-a61e-29e7e6893d04">

- 특정 상태 조회 
<img width="671" alt="스크린샷 2024-07-13 오전 1 29 22" src="https://github.com/user-attachments/assets/a0e3c4e8-920a-4af0-83f3-095606b15a45">

- 상태에 맞는 신청한 모임이 없는 경우 예외 처리
<img width="680" alt="스크린샷 2024-07-13 오전 1 30 44" src="https://github.com/user-attachments/assets/e5808650-4042-43b6-9570-15de1f2cddb3">

