### PR TITLE
[feat] 신청자에 해당하는 신청 내역 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/host/dto/response/SubmittionDetailResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/SubmittionDetailResponse.java
@@ -1,0 +1,12 @@
+package com.pickple.server.api.host.dto.response;
+
+import com.pickple.server.api.moim.domain.QuestionInfo;
+import com.pickple.server.api.moimsubmission.domain.AnswerInfo;
+import lombok.Builder;
+
+@Builder
+public record SubmittionDetailResponse(
+        QuestionInfo questionList,
+        AnswerInfo answerList
+) {
+}

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -42,4 +42,12 @@ public class MoimSubmissionController {
         return ApiResponseDto.success(SuccessCode.SUBMITTED_MOIM_LIST_BY_GUEST_GET_SUCCESS,
                 moimSubmissionQueryService.getSubmittedMoimListByGuest(guestId, moimSubmissionState));
     }
+
+    @GetMapping("/v1/moim/{moimId}/submitter/{submitterId}")
+    public ApiResponseDto getSubmissionDetail(
+            @PathVariable Long moimId, @PathVariable Long submitterId
+    ) {
+        return ApiResponseDto.success(SuccessCode.SUBMISSION_DETAIL_GET_SUCCESS,
+                moimSubmissionQueryService.getSubmittionDetail(moimId, submitterId));
+    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/domain/MoimSubmission.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/domain/MoimSubmission.java
@@ -22,7 +22,7 @@ import org.hibernate.type.SqlTypes;
 
 @Entity
 @Getter
-@Table(name = "moimSubmission")
+@Table(name = "moimSubmissions")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -46,19 +46,4 @@ public class MoimSubmission extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private MoimSubmissionState moimSubmissionState;
-
-    @Builder
-    public MoimSubmission(
-            final Long guestId,
-            final Moim moim,
-            final AnswerInfo answerList,
-            final AccountInfo accountList,
-            final MoimSubmissionState moimSubmissionState
-    ) {
-        this.guestId = guestId;
-        this.moim = moim;
-        this.answerList = answerList;
-        this.accountList = accountList;
-        this.moimSubmissionState = moimSubmissionState;
-    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -12,4 +12,6 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     List<MoimSubmission> findAllByGuestId(Long guestId);
 
     List<MoimSubmission> findAllByMoimSubmissionState(MoimSubmissionState moimSubmissionState);
+
+    MoimSubmission findBymoimIdAndGuestId(Long moimId, Long guestId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -54,6 +54,10 @@ public class MoimSubmissionQueryService {
     public SubmittionDetailResponse getSubmittionDetail(Long moimId, Long guestId) {
         MoimSubmission submission = moimSubmissionRepository.findBymoimIdAndGuestId(moimId, guestId);
 
+        if (submission == null) {
+            throw new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND);
+        }
+
         return SubmittionDetailResponse.builder()
                 .answerList(submission.getAnswerList())
                 .questionList(submission.getMoim().getQuestionList())

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -2,6 +2,7 @@ package com.pickple.server.api.moimsubmission.service;
 
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.dto.response.SubmittionDetailResponse;
 import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
@@ -48,5 +49,14 @@ public class MoimSubmissionQueryService {
                         .imageUrl(oneMoimSubmission.getMoim().getImageList().getImageUrl1())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public SubmittionDetailResponse getSubmittionDetail(Long moimId, Long guestId) {
+        MoimSubmission submission = moimSubmissionRepository.findBymoimIdAndGuestId(moimId, guestId);
+
+        return SubmittionDetailResponse.builder()
+                .answerList(submission.getAnswerList())
+                .questionList(submission.getMoim().getQuestionList())
+                .build();
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_HEADER(40005, HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     MISSING_REQUIRED_PARAMETER(40006, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     DUPLICATION_MOIM_SUBMISSION(40007, HttpStatus.BAD_REQUEST, "이미 대기중인 모임입니다."),
+    MOIM_SUBMISSION_NOT_FOUND(40008, HttpStatus.BAD_REQUEST, "해당 모임에 신청한 내역이 없습니다."),
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -28,6 +28,7 @@ public enum SuccessCode {
     MOIM_BANNER_GET_SUCCESS(20016, HttpStatus.OK, "홈 배너 조회 성공"),
     HOST_BY_MOIM_GET_SUCCESS(20017, HttpStatus.OK, "모임에 해당하는 호스트 정보 조회 성공"),
     SUBMITTED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20018, HttpStatus.OK, "게스트에 해당하는 신청한 모임 리스트 조회 성공"),
+    SUBMISSION_DETAIL_GET_SUCCESS(20019, HttpStatus.OK, "신청자 해당하는 신청 내역 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #57 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
신청자에 해당하는 신청 내역 조회 api 구현했습니다.
모임에 신청한 내역이 없을 경우 예외 처리를 진행했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-07-13 오전 4 12 04" src="https://github.com/user-attachments/assets/2a11bebe-5dde-4997-871f-e986d03ff526">

<img width="1470" alt="스크린샷 2024-07-13 오전 4 11 51" src="https://github.com/user-attachments/assets/8b94211a-8493-4448-a59a-ac2c93796232">
