### PR TITLE
[feat] 모임에 해당하는 신청자 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/guest/repository/GuestRepository.java
+++ b/src/main/java/com/pickple/server/api/guest/repository/GuestRepository.java
@@ -14,8 +14,6 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
 
     Optional<Guest> findByUserId(Long userId);
 
-//    List<Guest> findGuestListByMoimId(Long moimId);
-
     default Guest findGuestByIdOrThrow(Long id) {
         return findGuestById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.GUEST_NOT_FOUND));

--- a/src/main/java/com/pickple/server/api/guest/repository/GuestRepository.java
+++ b/src/main/java/com/pickple/server/api/guest/repository/GuestRepository.java
@@ -14,6 +14,8 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
 
     Optional<Guest> findByUserId(Long userId);
 
+//    List<Guest> findGuestListByMoimId(Long moimId);
+
     default Guest findGuestByIdOrThrow(Long id) {
         return findGuestById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.GUEST_NOT_FOUND));

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -14,6 +14,8 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
 
     List<Moim> findMoimByHostId(Long hostId);
 
+    List<Moim> findMoimListById(Long Id);
+
     default Moim findMoimByIdOrThrow(Long id) {
         return findMoimById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_NOT_FOUND));

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -57,4 +57,10 @@ public class MoimSubmissionController {
         return ApiResponseDto.success(SuccessCode.COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS,
                 moimSubmissionQueryService.getCompletedMoimListByGuest(guestId));
     }
+
+    @GetMapping("/v1/moim/{moimId}/submitter-list")
+    public ApiResponseDto getSubmitterListByMoim(@PathVariable Long moimId) {
+        return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_BY_MOIM_GET_SUCCESS,
+                moimSubmissionQueryService.getSubmitterListByMoim(moimId));
+    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/domain/SubmitterInfo.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/domain/SubmitterInfo.java
@@ -1,0 +1,9 @@
+package com.pickple.server.api.moimsubmission.domain;
+
+public record SubmitterInfo(
+        Long submitterId,    //guest id
+        String nickname,    //신청자 닉네임
+        String submitterImageUrl,   //신청자 프로필 이미지
+        String submittedDate    //신청한 날짜 및 시간
+) {
+}

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
@@ -1,0 +1,12 @@
+package com.pickple.server.api.moimsubmission.dto.response;
+
+import com.pickple.server.api.moimsubmission.domain.SubmitterInfo;
+import lombok.Builder;
+
+@Builder
+public record MoimSubmissionByMoimResponse(
+        int maxGuest,    //신청자 최대 인원
+        Boolean isApprovable,    //승인가능여부
+        SubmitterInfo submitterList    //신청자 리스트
+) {
+}

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -16,6 +16,8 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     MoimSubmission findBymoimIdAndGuestId(Long moimId, Long guestId);
 
+    List<MoimSubmission> findMoimListByMoimId(Long moimId);
+
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -4,7 +4,6 @@ import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
 import com.pickple.server.api.host.dto.response.SubmittionDetailResponse;
 import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
-import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
 import com.pickple.server.api.moimsubmission.domain.SubmitterInfo;
@@ -28,7 +27,6 @@ public class MoimSubmissionQueryService {
 
     private final GuestRepository guestRepository;
     private final MoimSubmissionRepository moimSubmissionRepository;
-    private final MoimRepository moimRepository;
 
     public List<SubmittedMoimByGuestResponse> getSubmittedMoimListByGuest(final Long guestId,
                                                                           final String moimSubmissionState) {
@@ -95,7 +93,11 @@ public class MoimSubmissionQueryService {
 
     public List<MoimSubmissionByMoimResponse> getSubmitterListByMoim(Long moimId) {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
-        
+
+        if (moimSubmissionList.isEmpty()) {
+            throw new CustomException(ErrorCode.SUBMITTE_BY_MOIM_NOT_FOUND);
+        }
+
         return moimSubmissionList.stream()
                 .map(oneMoimSubmission -> MoimSubmissionByMoimResponse.builder()
                         .maxGuest(oneMoimSubmission.getMoim().getMaxGuest())

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -3,6 +3,7 @@ package com.pickple.server.api.moimsubmission.service;
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
 import com.pickple.server.api.host.dto.response.SubmittionDetailResponse;
+import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
@@ -12,6 +13,7 @@ import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.util.DateTimeUtil;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -101,18 +103,19 @@ public class MoimSubmissionQueryService {
         return moimSubmissionList.stream()
                 .map(oneMoimSubmission -> MoimSubmissionByMoimResponse.builder()
                         .maxGuest(oneMoimSubmission.getMoim().getMaxGuest())
-                        .isApprovable(isApprovable(oneMoimSubmission))
+                        .isApprovable(isApprovable(oneMoimSubmission.getMoim()))
                         .submitterList(getSubmitterInfo(oneMoimSubmission.getGuestId()))
                         .build())
                 .collect(Collectors.toList());
     }
 
-    private boolean isApprovable(MoimSubmission oneMoimSubmission) {
-        // 신청일
-        LocalDateTime createdAt = oneMoimSubmission.getCreatedAt();
+    private boolean isApprovable(Moim moim) {
+        // 모임일
+        System.out.println(moim.getId());
+        LocalDate date = moim.getDateList().getDate();
 
         // 마감일: 신청일 + 3일의 자정
-        LocalDateTime deadline = createdAt.plusDays(3).with(LocalTime.MIDNIGHT);
+        LocalDateTime deadline = date.minusDays(3).atTime(LocalTime.MIDNIGHT);
 
         // 현재 시간
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -97,7 +97,7 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
 
         if (moimSubmissionList.isEmpty()) {
-            throw new CustomException(ErrorCode.SUBMITTE_BY_MOIM_NOT_FOUND);
+            throw new CustomException(ErrorCode.SUBMITTER_BY_MOIM_NOT_FOUND);
         }
 
         return moimSubmissionList.stream()

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_PARAMETER(40006, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     DUPLICATION_MOIM_SUBMISSION(40007, HttpStatus.BAD_REQUEST, "이미 대기중인 모임입니다."),
     MOIM_SUBMISSION_NOT_FOUND(40008, HttpStatus.BAD_REQUEST, "해당 모임에 신청한 내역이 없습니다."),
-    SUBMITTE_BY_MOIM_NOT_FOUND(40009, HttpStatus.BAD_REQUEST, "해당 모임에 신청자가 없습니다."),
+    SUBMITTER_BY_MOIM_NOT_FOUND(40009, HttpStatus.BAD_REQUEST, "해당 모임에 신청자가 없습니다."),
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_PARAMETER(40006, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     DUPLICATION_MOIM_SUBMISSION(40007, HttpStatus.BAD_REQUEST, "이미 대기중인 모임입니다."),
     MOIM_SUBMISSION_NOT_FOUND(40008, HttpStatus.BAD_REQUEST, "해당 모임에 신청한 내역이 없습니다."),
+    SUBMITTE_BY_MOIM_NOT_FOUND(40009, HttpStatus.BAD_REQUEST, "해당 모임에 신청자가 없습니다."),
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -30,6 +30,7 @@ public enum SuccessCode {
     SUBMITTED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20018, HttpStatus.OK, "게스트에 해당하는 신청한 모임 리스트 조회 성공"),
     SUBMISSION_DETAIL_GET_SUCCESS(20019, HttpStatus.OK, "신청자 해당하는 신청 내역 조회 성공"),
     COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20019, HttpStatus.OK, "게스트에 해당하는 참가한 모임 리스트 조회 성공"),
+    SUBMITTER_LIST_BY_MOIM_GET_SUCCESS(20020, HttpStatus.OK, "모임에 해당하는 신청자 전체 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #63

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임에 해당하는 신청자 전체 조회 api를 구현했습니다.
    - 승인 가능 여부를 response에 전달하기 위해 isApprovable 메소드를 구현했습니다.
        - 승인신청정보에서 모임정보를 갖고와 모임일과 현재시간을 비교하여 판단했습니다.
    - 모임에 해당하는 신청자가 없을 경우 예외처리를 진행했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<img width="1470" alt="스크린샷 2024-07-13 오후 2 19 28" src="https://github.com/user-attachments/assets/f06f1d05-f457-4072-8e8e-ea752a4eda86">
<img width="1470" alt="스크린샷 2024-07-13 오후 2 20 00" src="https://github.com/user-attachments/assets/422e892e-9ad6-42e1-8779-a2fe818d4f64">


<!-- postman 스크린샷을 첨부해주세요 -->