### PR TITLE
[feat] 호스트와 모임상태에 해당하는 모임 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -72,4 +72,10 @@ public class MoimController {
         return ApiResponseDto.success(SuccessCode.MOIM_BANNER_GET_SUCCESS,
                 moimQueryService.getMoimBanner());
     }
+
+    @GetMapping("/v1/host/{hostId}/moim-list")
+    public ApiResponseDto getMoimListByHostId(@PathVariable Long hostId, @RequestParam String moimState) {
+        return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST,
+                moimQueryService.getMoimListByHost(hostId, moimState));
+    }
 }

--- a/src/main/java/com/pickple/server/api/moim/domain/enums/MoimState.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/enums/MoimState.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MoimState {
 
-    ONGOING("ongoing"),
+    ONGOING("ongoing"), //진행중
 
-    COMPLETED("completed");
+    COMPLETED("completed"); //완료
 
     public final String moimState;
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostGetResponse.java
@@ -1,0 +1,13 @@
+package com.pickple.server.api.moim.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MoimListByHostGetResponse(
+        Long moimId,            //모임 id
+        String title,          //모임 제목
+        Long approvedGuest,     //승인된 인원
+        int maxGuest,          //최대 참가인원
+        String moimImage       //모임 대표 이미지
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -14,7 +14,7 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
 
     List<Moim> findMoimByHostId(Long hostId);
 
-    List<Moim> findMoimListById(Long Id);
+    List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
 
     default Moim findMoimByIdOrThrow(Long id) {
         return findMoimById(id)

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,6 +112,11 @@ public class MoimQueryService {
     }
 
     private Long calculateApprovedGuest(Long moimId) {
-        return moimSubmissionRepository.countApprovedMoimSubmissions(moimId);
+        try {
+            return moimSubmissionRepository.countApprovedMoimSubmissions(moimId);
+        } catch (InvalidDataAccessResourceUsageException e) {
+            // 테이블이 존재하지 않아서 발생한 예외일 경우 0 반환
+            return 0L;
+        }
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -5,8 +5,12 @@ import com.pickple.server.api.moim.domain.QuestionInfo;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
+import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.util.DateUtil;
 import java.util.List;
 import java.util.Random;
@@ -22,6 +26,7 @@ public class MoimQueryService {
 
     private final MoimRepository moimRepository;
     private final Random random = new Random();
+    private final MoimSubmissionRepository moimSubmissionRepository;
 
     public MoimDetailResponse getMoimDetail(final Long moimId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
@@ -87,5 +92,25 @@ public class MoimQueryService {
 
         int randomIndex = random.nextInt(moimIdList.size());
         return moimIdList.get(randomIndex);
+    }
+
+    public List<MoimListByHostGetResponse> getMoimListByHost(Long hostId, String moimState) {
+        List<Moim> moimList = moimRepository.findMoimByhostIdAndMoimState(hostId, moimState);
+        if (moimList.isEmpty()) {
+            throw new CustomException(ErrorCode.MOIM_BY_HOST_AND_STATE_NOT_FOUND);
+        }
+        return moimList.stream()
+                .map(oneMoim -> MoimListByHostGetResponse.builder()
+                        .moimId(oneMoim.getId())
+                        .moimImage(oneMoim.getImageList().getImageUrl1())
+                        .approvedGuest(calculateApprovedGuest(oneMoim.getId()))
+                        .title(oneMoim.getTitle())
+                        .maxGuest(oneMoim.getMaxGuest())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private Long calculateApprovedGuest(Long moimId) {
+        return moimSubmissionRepository.countApprovedMoimSubmissions(moimId);
     }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/domain/MoimSubmissionState.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/domain/MoimSubmissionState.java
@@ -7,19 +7,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MoimSubmissionState {
 
-    ALL("all"),
+    ALL("all"), //전체
 
-    PENDING_PAYMENT("pendingPayment"),
+    PENDING_PAYMENT("pendingPayment"),  //입금 대기
 
-    PENDING_APPROVAL("pendingApproval"),
+    PENDING_APPROVAL("pendingApproval"),    //승인 대기
 
-    APPROVED("approved"),
+    APPROVED("approved"),   //승인
 
-    REJECTED("rejected"),
+    REJECTED("rejected"),   //거절
 
-    REFUNDED("refunded"),
+    REFUNDED("refunded"),   //환불
 
-    COMPLETED("completed");
+    COMPLETED("completed"); //완료
 
     public final String moimSubmissionState;
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -20,4 +20,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
+
+    @Query(value = "SELECT COUNT(*) FROM moim_submissions WHERE moim_id = :moimId AND moim_submission_state = 'approved'", nativeQuery = true)
+    long countApprovedMoimSubmissions(@Param("moimId") Long moimId);
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     MOIM_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     HOST_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다"),
     MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
+    MOIM_BY_HOST_AND_STATE_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
 
     //405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -32,6 +32,7 @@ public enum SuccessCode {
     COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20019, HttpStatus.OK, "게스트에 해당하는 참가한 모임 리스트 조회 성공"),
     SUBMITTER_LIST_BY_MOIM_GET_SUCCESS(20020, HttpStatus.OK, "모임에 해당하는 신청자 전체 조회 성공"),
     SUBMITTER_APPROVE_SUCCESS(20020, HttpStatus.OK, "신청자 승인 성공"),
+    MOIM_LIST_BY_HOST(20021, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
 
     //201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #67 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 - 예외처리를 진행했습니다
     - 호스트와 상태에 맞는 경우가 없는경우
     - 승인된 인원이 없는경우

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<img width="1470" alt="스크린샷 2024-07-13 오후 4 43 18" src="https://github.com/user-attachments/assets/645f64ca-2e80-4c4c-b5e4-168569ab97da">

<img width="1470" alt="스크린샷 2024-07-13 오후 4 43 35" src="https://github.com/user-attachments/assets/0fd5f8f2-0761-4b17-a15b-52483d5ef0c0">
