### PR TITLE
[refactor] 신청자 승인 API 리팩토링

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.moimsubmission.controller;
 
 import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitRequest;
+import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitterUpdateRequest;
 import com.pickple.server.api.moimsubmission.service.MoimSubmissionCommandService;
 import com.pickple.server.api.moimsubmission.service.MoimSubmissionQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
@@ -65,9 +66,12 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
                 moimSubmissionQueryService.getSubmitterListByMoim(moimId));
     }
 
-    @PatchMapping("/v1/moim/{moimId}/submitter/{submitterId}")
-    public ApiResponseDto updateSubmitterState(@PathVariable Long moimId, @PathVariable Long submitterId) {
-        moimSubmissionCommandService.updateSubmissionState(moimId, submitterId);
+    @PatchMapping("/v1/moim/{moimId}/submitter")
+    public ApiResponseDto updateSubmitterState(
+            @PathVariable Long moimId,
+            @RequestBody MoimSubmitterUpdateRequest moimSubmitterUpdateRequest
+    ) {
+        moimSubmissionCommandService.updateSubmissionState(moimId, moimSubmitterUpdateRequest.submitterIdList());
         return ApiResponseDto.success(SuccessCode.SUBMITTER_APPROVE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.pickple.server.api.moimsubmission.dto.request;
+
+import java.util.List;
+
+public record MoimSubmitterUpdateRequest(
+        List<Long> submitterIdList
+) {
+}

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -16,6 +16,8 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     MoimSubmission findBymoimIdAndGuestId(Long moimId, Long guestId);
 
+    List<MoimSubmission> findByMoimIdAndGuestIdIn(Long moimId, List<Long> submitterIdList);
+
     List<MoimSubmission> findMoimListByMoimId(Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -44,7 +44,6 @@ public class MoimSubmissionCommandService {
     public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findByMoimIdAndGuestIdIn(moimId,
                 submitterIdList);
-        System.out.println(moimSubmissionList);
         for (MoimSubmission moimSubmission : moimSubmissionList) {
             moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
             moimSubmissionRepository.save(moimSubmission);

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -8,6 +8,7 @@ import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitRequest;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
 import com.pickple.server.global.exception.BadRequestException;
 import com.pickple.server.global.response.enums.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,9 +41,13 @@ public class MoimSubmissionCommandService {
         }
     }
 
-    public void updateSubmissionState(Long moimId, Long submitterId) {
-        MoimSubmission moimSubmission = moimSubmissionRepository.findBymoimIdAndGuestId(moimId, submitterId);
-        moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
-        moimSubmissionRepository.save(moimSubmission);
+    public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findByMoimIdAndGuestIdIn(moimId,
+                submitterIdList);
+        System.out.println(moimSubmissionList);
+        for (MoimSubmission moimSubmission : moimSubmissionList) {
+            moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+            moimSubmissionRepository.save(moimSubmission);
+        }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #70 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 신청자 승인 API 리팩토링
  - RequestBody로 해당 모임 신청자들의 Id 리스트를 받아왔습니다.
  - 해당 신청자들의 MoimSubmissonState를 일괄로 approved 처리할 수 있도록 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<img width="1135" alt="스크린샷 2024-07-14 오후 4 34 42" src="https://github.com/user-attachments/assets/7d23a516-55fa-496a-bc8b-506abb72826f">

<img width="1138" alt="스크린샷 2024-07-14 오후 5 01 14" src="https://github.com/user-attachments/assets/11e85222-746d-4a84-a32f-a21696410062">

<img width="684" alt="스크린샷 2024-07-14 오후 5 02 41" src="https://github.com/user-attachments/assets/1fa58b93-3be7-4d70-b133-4b5117f87888">

<!-- postman 스크린샷을 첨부해주세요 -->
