### PR TITLE
[fix] GET API들의 ApiResponseDto 타입 지정

### DIFF
--- a/src/main/java/com/pickple/server/api/host/controller/HostController.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostController.java
@@ -1,5 +1,7 @@
 package com.pickple.server.api.host.controller;
 
+import com.pickple.server.api.host.dto.response.HostByMoimResponse;
+import com.pickple.server.api.host.dto.response.HostGetResponse;
 import com.pickple.server.api.host.service.HostQueryService;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
@@ -18,12 +20,12 @@ public class HostController implements HostControllerDocs {
     private final HostQueryService hostQueryService;
 
     @GetMapping("/v1/host")
-    public ApiResponseDto getHost(@HostId Long hostId) {
+    public ApiResponseDto<HostGetResponse> getHost(@HostId Long hostId) {
         return ApiResponseDto.success(SuccessCode.HOST_DETAIL_GET_SUCCESS, hostQueryService.getHost(hostId));
     }
 
     @GetMapping("/v1/host/{hostId}")
-    public ApiResponseDto getMoimHost(@PathVariable Long hostId) {
+    public ApiResponseDto<HostByMoimResponse> getMoimHost(@PathVariable Long hostId) {
         return ApiResponseDto.success(SuccessCode.HOST_BY_MOIM_GET_SUCCESS, hostQueryService.getHostByMoim(hostId));
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -1,8 +1,12 @@
 package com.pickple.server.api.moim.controller;
 
+import com.pickple.server.api.moim.domain.QuestionInfo;
 import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
+import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
+import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
@@ -50,31 +54,32 @@ public class MoimController implements MoimControllerDocs {
     }
 
     @GetMapping("/v1/moim-list")
-    public ApiResponseDto getMoimListByCategory(@RequestParam String category) {
+    public ApiResponseDto<List<MoimByCategoryResponse>> getMoimListByCategory(@RequestParam String category) {
         return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_CATEGORY_GET_SUCCESS,
                 moimQueryService.getMoimListByCategory(category));
     }
 
     @GetMapping("/v1/moim/{moimId}/description")
-    public ApiResponseDto getMoimDescription(@PathVariable Long moimId) {
+    public ApiResponseDto<MoimDescriptionResponse> getMoimDescription(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.MOIM_DESCRIPTION_GET_SUCCESS,
                 moimQueryService.getMoimDescription(moimId));
     }
 
     @GetMapping("/v1/moim/{moimId}/question-list")
-    public ApiResponseDto getMoimQuestionList(@PathVariable Long moimId) {
+    public ApiResponseDto<QuestionInfo> getMoimQuestionList(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.MOIM_QUESTION_LIST_GET_SUCCESS,
                 moimQueryService.getMoimQuestionList(moimId));
     }
 
     @GetMapping("/v1/moim/banner")
-    public ApiResponseDto getMoimBanner() {
+    public ApiResponseDto<Long> getMoimBanner() {
         return ApiResponseDto.success(SuccessCode.MOIM_BANNER_GET_SUCCESS,
                 moimQueryService.getMoimBanner());
     }
 
     @GetMapping("/v1/host/{hostId}/moim-list")
-    public ApiResponseDto getMoimListByHostId(@PathVariable Long hostId, @RequestParam String moimState) {
+    public ApiResponseDto<List<MoimListByHostGetResponse>> getMoimListByHostId(@PathVariable Long hostId,
+                                                                               @RequestParam String moimState) {
         return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST,
                 moimQueryService.getMoimListByHost(hostId, moimState));
     }

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -1,12 +1,16 @@
 package com.pickple.server.api.moimsubmission.controller;
 
+import com.pickple.server.api.host.dto.response.SubmittionDetailResponse;
+import com.pickple.server.api.moim.dto.response.SubmittedMoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitRequest;
 import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitterUpdateRequest;
+import com.pickple.server.api.moimsubmission.dto.response.MoimSubmissionByMoimResponse;
 import com.pickple.server.api.moimsubmission.service.MoimSubmissionCommandService;
 import com.pickple.server.api.moimsubmission.service.MoimSubmissionQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,7 +40,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     }
 
     @GetMapping("/v1/guest/{guestId}/submitted-moim-list")
-    public ApiResponseDto getSubmittedMoimListByGuest(
+    public ApiResponseDto<List<SubmittedMoimByGuestResponse>> getSubmittedMoimListByGuest(
             @PathVariable Long guestId,
             @RequestParam String moimSubmissionState
     ) {
@@ -45,7 +49,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     }
 
     @GetMapping("/v1/moim/{moimId}/submitter/{submitterId}")
-    public ApiResponseDto getSubmissionDetail(
+    public ApiResponseDto<SubmittionDetailResponse> getSubmissionDetail(
             @PathVariable Long moimId, @PathVariable Long submitterId
     ) {
         return ApiResponseDto.success(SuccessCode.SUBMISSION_DETAIL_GET_SUCCESS,
@@ -53,7 +57,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     }
 
     @GetMapping("/v1/guest/{guestId}/completed-moim-list")
-    public ApiResponseDto getCompletedMoimListByGuest(
+    public ApiResponseDto<List<SubmittedMoimByGuestResponse>> getCompletedMoimListByGuest(
             @PathVariable Long guestId
     ) {
         return ApiResponseDto.success(SuccessCode.COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS,
@@ -61,7 +65,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     }
 
     @GetMapping("/v1/moim/{moimId}/submitter-list")
-    public ApiResponseDto getSubmitterListByMoim(@PathVariable Long moimId) {
+    public ApiResponseDto<List<MoimSubmissionByMoimResponse>> getSubmitterListByMoim(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_BY_MOIM_GET_SUCCESS,
                 moimSubmissionQueryService.getSubmitterListByMoim(moimId));
     }

--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -30,7 +30,7 @@ public class NoticeController implements NoticeControllerDocs {
         return ApiResponseDto.success(SuccessCode.NOTICE_POST_SUCCESS);
     }
 
-    @GetMapping("/v1/moim/{moimId}/noitce-list")
+    @GetMapping("/v1/moim/{moimId}/notice-list")
     public ApiResponseDto<List<NoticeListGetByMoimResponse>> getNoticeListByMoimId(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.NOTICE_LIST_GET_SUCCESS,
                 noticeQueryService.getNoticeListByMoimId(moimId));

--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -1,10 +1,12 @@
 package com.pickple.server.api.notice.controller;
 
 import com.pickple.server.api.notice.dto.request.NoticeCreateRequest;
+import com.pickple.server.api.notice.dto.response.NoticeListGetByMoimResponse;
 import com.pickple.server.api.notice.service.NoticeCommandService;
 import com.pickple.server.api.notice.service.NoticeQueryService;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,7 +31,7 @@ public class NoticeController implements NoticeControllerDocs {
     }
 
     @GetMapping("/v1/moim/{moimId}/noitce-list")
-    public ApiResponseDto getNoticeListByMoimId(@PathVariable Long moimId) {
+    public ApiResponseDto<List<NoticeListGetByMoimResponse>> getNoticeListByMoimId(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.NOTICE_LIST_GET_SUCCESS,
                 noticeQueryService.getNoticeListByMoimId(moimId));
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #76 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- GET API들의 ApiResponseDto 타입 지정
  - ApiResponseDto 각각에 맞는 response 타입을 지정해주었습니다.
  - url 오타를 수정했습니다.
  
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 보람보람 화이팅

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 생략