### PR TITLE
[fix] 호스트 승인 신청 시 중복 닉네임 방지 예외처리 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/host/repository/HostRepository.java
+++ b/src/main/java/com/pickple/server/api/host/repository/HostRepository.java
@@ -16,4 +16,6 @@ public interface HostRepository extends JpaRepository<Host, Long> {
         return findHostById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.HOST_NOT_FOUND));
     }
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
+++ b/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubmitterRepository extends JpaRepository<Submitter, Long> {
     boolean existsByGuestAndSubmitterState(Guest guest, String submitterState);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
@@ -3,11 +3,13 @@ package com.pickple.server.api.submitter.service;
 
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.repository.HostRepository;
 import com.pickple.server.api.submitter.domain.Submitter;
 import com.pickple.server.api.submitter.domain.SubmitterState;
 import com.pickple.server.api.submitter.dto.request.SubmitterCreateRequest;
 import com.pickple.server.api.submitter.repository.SubmitterRepository;
 import com.pickple.server.global.exception.BadRequestException;
+import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,11 @@ public class SubmitterCommandService {
 
     private final GuestRepository guestRepository;
     private final SubmitterRepository submitterRepository;
+    private final HostRepository hostRepository;
 
     public void createSubmitter(Long guestId, SubmitterCreateRequest request) {
         Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
+        isDuplicatedNickname(request.nickname());
         Submitter submitter = Submitter.builder()
                 .guest(guest)
                 .intro(request.intro())
@@ -34,13 +38,21 @@ public class SubmitterCommandService {
                 .plan(request.plan())
                 .submitterState(SubmitterState.PENDING.getSubmitterState())
                 .build();
-        isDulicatedSubmition(submitter);
+        isDuplicatedSubmission(submitter);
         submitterRepository.save(submitter);
     }
 
-    private void isDulicatedSubmition(Submitter submitter) {
+    private void isDuplicatedSubmission(Submitter submitter) {
         if (submitterRepository.existsByGuestAndSubmitterState(submitter.getGuest(), submitter.getSubmitterState())) {
             throw new BadRequestException(ErrorCode.DUPLICATION_SUBMITTER);
+        }
+    }
+
+    private void isDuplicatedNickname(String nickname) {
+        if (hostRepository.existsByNickname(nickname)) {
+            throw new CustomException(ErrorCode.DUPLICATION_HOST_NICKNAME);
+        } else if (submitterRepository.existsByNickname(nickname)) {
+            throw new CustomException(ErrorCode.DUPLICATION_HOST_NICKNAME);
         }
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_HEADER(40005, HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     MISSING_REQUIRED_PARAMETER(40006, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     DUPLICATION_MOIM_SUBMISSION(40007, HttpStatus.BAD_REQUEST, "이미 대기중인 모임입니다."),
+    DUPLICATION_HOST_NICKNAME(40008, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #77 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 승인 신청 시 중복 닉네임 방지 예외처리 추가
  - 호스트 승인 신청 테이블에 중복 닉네임이 있는지에 대한 예외처리를 진행했습니다.
  - 호스트 테이블에 중복 닉네임이 있는지에 대한 예외처리를 진행했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 바쁘다바빠현대사회

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 호스트 승인 신청 테이블에 중복 닉네임이 있을 때
<img width="958" alt="스크린샷 2024-07-16 오전 2 11 19" src="https://github.com/user-attachments/assets/d41957cc-9b38-48fb-82bf-12f136ae8b99">

- 호스트 테이블에 중복 닉네임이 있을 때
<img width="976" alt="스크린샷 2024-07-16 오전 2 10 40" src="https://github.com/user-attachments/assets/7c77bfff-1230-42e8-87df-4c93755b4895">
