### PR TITLE
[fix] 모임에 해당하는 신청자 전체 조회 api 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -65,7 +65,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     }
 
     @GetMapping("/v1/moim/{moimId}/submitter-list")
-    public ApiResponseDto<List<MoimSubmissionByMoimResponse>> getSubmitterListByMoim(@PathVariable Long moimId) {
+    public ApiResponseDto<MoimSubmissionByMoimResponse> getSubmitterListByMoim(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_BY_MOIM_GET_SUCCESS,
                 moimSubmissionQueryService.getSubmitterListByMoim(moimId));
     }

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
@@ -1,12 +1,13 @@
 package com.pickple.server.api.moimsubmission.dto.response;
 
 import com.pickple.server.api.moimsubmission.domain.SubmitterInfo;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record MoimSubmissionByMoimResponse(
         int maxGuest,    //신청자 최대 인원
         Boolean isApprovable,    //승인가능여부
-        SubmitterInfo submitterList    //신청자 리스트
+        List<SubmitterInfo> submitterList    //신청자 리스트
 ) {
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #82 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
응답을 잘못 내려드리고 있어서 수정하였습니다.
- 기존은 응답 전체를(MoimSubmissionByMoimResponse) list로 감싸고 신청자 정보를(submitterInfoList) 객체로 하나씩 내려드렸습니다.
    ```{
     "status": 20021,
     "message": "모임에 해당하는 신청자 전체 조회 성공",
     "data": {
       "maxGuest": 15,
       "isApprovable": false,
       "submitterList": [{
        "submitterId": 9,
        "nickname": "장정안#9",
        "submitterImageUrl": "testImage",
        "submittedDate": "2024.07.15 17:04:08"
       },
    	    {
        "submitterId": 9,
        "nickname": "장정안#9",
        "submitterImageUrl": "testImage",
        "submittedDate": "2024.07.15 17:04:08"
       },
	{
        "submitterId": 9,
        "nickname": "장정안#9",
        "submitterImageUrl": "testImage",
        "submittedDate": "2024.07.15 17:04:08"
       }
      ]
     }
    }```


- 수정버전은 응답을(MoimSubmissionByMoimResponse) 한 객체로 내려드리고 신청자 정보(submitterInfoList)를 list로 수정하였습니다.
    ```{
    "status": 20021,
    "message": "모임에 해당하는 신청자 전체 조회 성공",
    "data": {
        "maxGuest": 15,
        "isApprovable": true,
        "submitterList": [
            {
                "submitterId": 2,
                "nickname": "PICK!PLE#2",
                "submitterImageUrl": "testImage",
                "submittedDate": "2024.07.13 16:09:52"
            },
            {
                "submitterId": 1,
                "nickname": "김보람#1",
                "submitterImageUrl": "testImage",
                "submittedDate": "2024.07.13 15:53:42"
            }
        ]
    }
    }```

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
잘할게요ㅠ.ㅠ

## 📬 Postman
<img width="1470" alt="스크린샷 2024-07-16 오후 6 39 10" src="https://github.com/user-attachments/assets/1595abe1-fb28-4715-b212-af0de5332c8e">

<!-- postman 스크린샷을 첨부해주세요 -->