### PR TITLE
[hotfix] 모임 중복 신청 예외처리 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, Long> {
-    boolean existsByMoimAndMoimSubmissionState(Moim moim, String moimSubmissionState);
+    boolean existsByMoimAndMoimSubmissionStateAndGuestId(Moim moim, String moimSubmissionState, Long guestId);
 
     List<MoimSubmission> findAllByGuestId(Long guestId);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -35,8 +35,8 @@ public class MoimSubmissionCommandService {
     }
 
     private void isDuplicatedMoimSubmission(MoimSubmission moimSubmission) {
-        if (moimSubmissionRepository.existsByMoimAndMoimSubmissionState(moimSubmission.getMoim(),
-                moimSubmission.getMoimSubmissionState())) {
+        if (moimSubmissionRepository.existsByMoimAndMoimSubmissionStateAndGuestId(moimSubmission.getMoim(),
+                moimSubmission.getMoimSubmissionState(), moimSubmission.getGuestId())) {
             throw new BadRequestException(ErrorCode.DUPLICATION_MOIM_SUBMISSION);
         }
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #84 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 중복 예외처리 수정 진행
  - 신청자의 guestId 값을 같이 확인하여 중복 신청인지 아닌지 판별하도록 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 김보람바부

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 채연 토큰
<img width="674" alt="스크린샷 2024-07-16 오후 8 55 26" src="https://github.com/user-attachments/assets/b597dcea-48ea-4c00-9393-0fcfab30fb67">

- 예린 토큰
<img width="623" alt="스크린샷 2024-07-16 오후 8 56 00" src="https://github.com/user-attachments/assets/257bcec6-4e76-400d-81e9-17c2e34da7e9">

- DB에 정상적으로 들어오는 것을 확인했습니다.
<img width="641" alt="스크린샷 2024-07-16 오후 8 56 13" src="https://github.com/user-attachments/assets/f43663f8-2279-4e8b-8dd2-d4d9d425bcb1">

- 같은 사용자인 경우 중복 신청 예외처리 됩니다.
<img width="627" alt="스크린샷 2024-07-16 오후 9 03 30" src="https://github.com/user-attachments/assets/d18deeaf-cfe1-41b4-8ee7-85066be51dbc">

