### PR TITLE
[feat] 호스트 승인 신청 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -1,11 +1,15 @@
 package com.pickple.server.api.submitter.controller;
 
 import com.pickple.server.api.submitter.dto.request.SubmitterCreateRequest;
+import com.pickple.server.api.submitter.dto.response.SubmitterGetResponse;
 import com.pickple.server.api.submitter.service.SubmitterCommandService;
+import com.pickple.server.api.submitter.service.SubmitterQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,11 +21,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class SubmitterController implements SubmitterControllerDocs {
 
     private final SubmitterCommandService submitterCommandService;
+    private final SubmitterQueryService submitterQueryService;
 
     @PostMapping("/v1/submitter")
     public ApiResponseDto postSubmitter(@GuestId final Long guestId,
                                         @RequestBody SubmitterCreateRequest submitterCreateRequest) {
         submitterCommandService.createSubmitter(guestId, submitterCreateRequest);
         return ApiResponseDto.success(SuccessCode.SUBMITTER_POST_SUCCESS);
+    }
+
+    @GetMapping("v1/submitter-list")
+    public ApiResponseDto<List<SubmitterGetResponse>> getSubmitterList() {
+        return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS, submitterQueryService.getSubmitterList());
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -1,7 +1,7 @@
 package com.pickple.server.api.submitter.controller;
 
 import com.pickple.server.api.submitter.dto.request.SubmitterCreateRequest;
-import com.pickple.server.api.submitter.dto.response.SubmitterGetResponse;
+import com.pickple.server.api.submitter.dto.response.SubmitterListGetResponse;
 import com.pickple.server.api.submitter.service.SubmitterCommandService;
 import com.pickple.server.api.submitter.service.SubmitterQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
@@ -31,7 +31,7 @@ public class SubmitterController implements SubmitterControllerDocs {
     }
 
     @GetMapping("v1/submitter-list")
-    public ApiResponseDto<List<SubmitterGetResponse>> getSubmitterList() {
+    public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList() {
         return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS, submitterQueryService.getSubmitterList());
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterGetResponse.java
+++ b/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterGetResponse.java
@@ -1,0 +1,29 @@
+package com.pickple.server.api.submitter.dto.response;
+
+import com.pickple.server.api.submitter.domain.SubmitterCategoryInfo;
+import lombok.Builder;
+
+@Builder
+public record SubmitterGetResponse(
+        String guestNickname,
+        Long guestId,
+
+        Long submitterId,
+
+        String intro,
+
+        String goal,
+
+        String link,
+
+        String nickname,
+
+        SubmitterCategoryInfo categoryList,
+
+        String plan,
+
+        String email,
+
+        String submitterState
+) {
+}

--- a/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterListGetResponse.java
+++ b/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterListGetResponse.java
@@ -4,7 +4,7 @@ import com.pickple.server.api.submitter.domain.SubmitterCategoryInfo;
 import lombok.Builder;
 
 @Builder
-public record SubmitterGetResponse(
+public record SubmitterListGetResponse(
         String guestNickname,
         Long guestId,
 

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
@@ -2,7 +2,7 @@ package com.pickple.server.api.submitter.service;
 
 
 import com.pickple.server.api.submitter.domain.Submitter;
-import com.pickple.server.api.submitter.dto.response.SubmitterGetResponse;
+import com.pickple.server.api.submitter.dto.response.SubmitterListGetResponse;
 import com.pickple.server.api.submitter.repository.SubmitterRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,11 +17,11 @@ public class SubmitterQueryService {
 
     private final SubmitterRepository submitterRepository;
 
-    public List<SubmitterGetResponse> getSubmitterList() {
+    public List<SubmitterListGetResponse> getSubmitterList() {
         List<Submitter> submitterList = submitterRepository.findAll();
 
         return submitterList.stream()
-                .map(submitter -> SubmitterGetResponse.builder()
+                .map(submitter -> SubmitterListGetResponse.builder()
                         .guestNickname(submitter.getGuest().getNickname())
                         .guestId(submitter.getGuest().getId())
                         .submitterId(submitter.getId())

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
@@ -1,0 +1,39 @@
+package com.pickple.server.api.submitter.service;
+
+
+import com.pickple.server.api.submitter.domain.Submitter;
+import com.pickple.server.api.submitter.dto.response.SubmitterGetResponse;
+import com.pickple.server.api.submitter.repository.SubmitterRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubmitterQueryService {
+
+    private final SubmitterRepository submitterRepository;
+
+    public List<SubmitterGetResponse> getSubmitterList() {
+        List<Submitter> submitterList = submitterRepository.findAll();
+
+        return submitterList.stream()
+                .map(submitter -> SubmitterGetResponse.builder()
+                        .guestNickname(submitter.getGuest().getNickname())
+                        .guestId(submitter.getGuest().getId())
+                        .submitterId(submitter.getId())
+                        .intro(submitter.getIntro())
+                        .goal(submitter.getGoal())
+                        .link(submitter.getLink())
+                        .nickname(submitter.getNickname())
+                        .categoryList(submitter.getCategoryList())
+                        .plan(submitter.getPlan())
+                        .email(submitter.getEmail())
+                        .submitterState(submitter.getSubmitterState())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -33,6 +33,7 @@ public enum SuccessCode {
     SUBMITTER_LIST_BY_MOIM_GET_SUCCESS(20021, HttpStatus.OK, "모임에 해당하는 신청자 전체 조회 성공"),
     SUBMITTER_APPROVE_SUCCESS(20022, HttpStatus.OK, "신청자 승인 성공"),
     MOIM_LIST_BY_HOST(20023, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
+    SUBMITTER_LIST_GET_SUCCESS(20024, HttpStatus.OK, "호스트 승인 신청 내역 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #86 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 승인 신청 내역 조회 API 구현

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 원래 response에서 SubmitAnswerList로 한번 묶어주려고 했으나 클라쌤과 논의 후 그냥 개별로 주는 것으로 구현했습니다.

## 📬 Postman
<img width="630" alt="스크린샷 2024-07-17 오전 3 39 15" src="https://github.com/user-attachments/assets/b1d270f5-f9aa-4a82-905a-c45894f5b400">

<!-- postman 스크린샷을 첨부해주세요 -->