### PR TITLE
[hotfix] 모임에 해당하는 신청자 전체 조회 API 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -101,9 +101,6 @@ public class MoimSubmissionQueryService {
         // moimSubmissionList 가져오기
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
 
-        if (moimSubmissionList.isEmpty()) {
-            throw new CustomException(ErrorCode.SUBMITTER_BY_MOIM_NOT_FOUND);
-        }
         // guestId를 추출하여 리스트에 저장
         List<Long> guestIdList = moimSubmissionList.stream()
                 .map(MoimSubmission::getGuestId)

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -34,7 +34,6 @@ public enum ErrorCode {
     MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
     MOIM_SUBMISSION_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
     MOIM_BY_HOST_AND_STATE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
-    SUBMITTER_BY_MOIM_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "해당 모임에 신청자가 없습니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #90

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 신청자 비어있는 경우 빈 배열로 반환하도록 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 클라에서 이전 로직의 경우 에러 처리 시 데이터에 들어있는 maxGuest 값을 사용할 수 없다는 문제를 알려주셔서 해당 부분을 빈 배열로 반환하도록 수정했습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="630" alt="스크린샷 2024-07-17 오전 5 31 15" src="https://github.com/user-attachments/assets/48d08d2f-8a1b-455e-895d-b2a9d09b48c2">
