### PR TITLE
[hotfix] 로그인시 host정보 불러오는 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/host/repository/HostRepository.java
+++ b/src/main/java/com/pickple/server/api/host/repository/HostRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HostRepository extends JpaRepository<Host, Long> {
 
+    boolean existsByUserId(Long userId);
+
     Host findHostByUserId(Long userId);
 
     Optional<Host> findHostById(Long id);

--- a/src/main/java/com/pickple/server/api/user/service/UserService.java
+++ b/src/main/java/com/pickple/server/api/user/service/UserService.java
@@ -148,7 +148,7 @@ public class UserService {
     }
 
     private boolean isExistingHost(final Long userId) {
-        return hostRepository.existsById(userId);
+        return hostRepository.existsByUserId(userId);
     }
 
     private Guest getOrCreateGuest(final User user) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #95 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
로그인 시 host권한이 있는지 확인할 때 userId로 검증해야하는데 isExistById로 되어있어서 userId와 hostId가 일치하지 않을때 정보를 불러오지 못하는 이슈였습니다.
모든 user가 host가 되는 것이 아니기때문에 충분히 발생할 수 있는 문제라고 생각해서 isExistByUserId로 수정하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
일단 머지 후 예린이 인가코드로 서버에서 테스트해봅시다

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->

<img width="1470" alt="스크린샷 2024-07-17 오후 1 23 50" src="https://github.com/user-attachments/assets/bfbdff39-5f0d-4567-b868-c822b9028387">

<img width="1034" alt="스크린샷 2024-07-17 오후 1 23 38" src="https://github.com/user-attachments/assets/93260535-611a-4fb0-a26c-4190c39dc631">
