### PR TITLE
[feat] 호스트 승인 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -76,6 +76,6 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
             @RequestBody MoimSubmitterUpdateRequest moimSubmitterUpdateRequest
     ) {
         moimSubmissionCommandService.updateSubmissionState(moimId, moimSubmitterUpdateRequest.submitterIdList());
-        return ApiResponseDto.success(SuccessCode.SUBMITTER_APPROVE_SUCCESS);
+        return ApiResponseDto.success(SuccessCode.MOIM_SUBMITTER_APPROVE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -10,6 +10,8 @@ import com.pickple.server.global.response.enums.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,8 +32,14 @@ public class SubmitterController implements SubmitterControllerDocs {
         return ApiResponseDto.success(SuccessCode.SUBMITTER_POST_SUCCESS);
     }
 
-    @GetMapping("v1/submitter-list")
+    @GetMapping("/v1/submitter-list")
     public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList() {
         return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS, submitterQueryService.getSubmitterList());
+    }
+
+    @PatchMapping("/v1/submitter/{submitterId}")
+    public ApiResponseDto approveSubmitter(@PathVariable("submitterId") final Long submitterId) {
+        submitterCommandService.approveSubmitter(submitterId);
+        return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -42,10 +42,11 @@ public class SubmitterController implements SubmitterControllerDocs {
     @PatchMapping("/v1/submitter/{submitterId}")
     public ApiResponseDto approveSubmitter(@PathVariable("submitterId") final Long submitterId,
                                            @UserId final Long userId) {
-        if (userId != 12 && userId != 13) {
-            ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
+        if (userId == 12 || userId == 13) {
+            submitterCommandService.approveSubmitter(submitterId);
+            return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
+        } else {
+            return ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
         }
-        submitterCommandService.approveSubmitter(submitterId);
-        return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -5,7 +5,9 @@ import com.pickple.server.api.submitter.dto.response.SubmitterListGetResponse;
 import com.pickple.server.api.submitter.service.SubmitterCommandService;
 import com.pickple.server.api.submitter.service.SubmitterQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
+import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
+import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.response.enums.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +40,11 @@ public class SubmitterController implements SubmitterControllerDocs {
     }
 
     @PatchMapping("/v1/submitter/{submitterId}")
-    public ApiResponseDto approveSubmitter(@PathVariable("submitterId") final Long submitterId) {
+    public ApiResponseDto approveSubmitter(@PathVariable("submitterId") final Long submitterId,
+                                           @UserId final Long userId) {
+        if (userId != 12 && userId != 13) {
+            ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
+        }
         submitterCommandService.approveSubmitter(submitterId);
         return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
     }

--- a/src/main/java/com/pickple/server/api/submitter/domain/Submitter.java
+++ b/src/main/java/com/pickple/server/api/submitter/domain/Submitter.java
@@ -50,4 +50,8 @@ public class Submitter extends BaseTimeEntity {
     private String email;
 
     private String submitterState;
+
+    public void updateSubmitterState(String submitterState) {
+        this.submitterState = submitterState;
+    }
 }

--- a/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
+++ b/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
@@ -2,10 +2,20 @@ package com.pickple.server.api.submitter.repository;
 
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.submitter.domain.Submitter;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubmitterRepository extends JpaRepository<Submitter, Long> {
     boolean existsByGuestAndSubmitterState(Guest guest, String submitterState);
+
+    Optional<Submitter> findSubmitterById(Long id);
+
+    default Submitter findSubmitterByIdOrThrow(Long id) {
+        return findSubmitterById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBMITTER_NOT_FOUND));
+    }
 
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
@@ -3,6 +3,8 @@ package com.pickple.server.api.submitter.service;
 
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.domain.Host;
+import com.pickple.server.api.host.domain.HostCategoryInfo;
 import com.pickple.server.api.host.repository.HostRepository;
 import com.pickple.server.api.submitter.domain.Submitter;
 import com.pickple.server.api.submitter.domain.SubmitterState;
@@ -40,6 +42,28 @@ public class SubmitterCommandService {
                 .build();
         isDuplicatedSubmission(submitter);
         submitterRepository.save(submitter);
+    }
+
+    public void approveSubmitter(Long submitterId) {
+        Submitter submitter = submitterRepository.findById(submitterId).orElseThrow();
+
+        submitter.updateSubmitterState(SubmitterState.APPROVE.getSubmitterState());
+
+        HostCategoryInfo hostCategoryInfo = HostCategoryInfo.builder()
+                .category1(submitter.getCategoryList().getCategory1())
+                .category2(submitter.getCategoryList().getCategory2())
+                .category3(submitter.getCategoryList().getCategory3())
+                .build();
+
+        Host host = Host.builder()
+                .categoryList(hostCategoryInfo)
+                .user(submitter.getGuest().getUser())
+                .link(submitter.getLink())
+                .imageUrl("https://pickple-bucket.s3.ap-northeast-2.amazonaws.com/profile/hostProfileImage.png")
+                .nickname(submitter.getNickname())
+                .build();
+
+        hostRepository.save(host);
     }
 
     private void isDuplicatedSubmission(Submitter submitter) {

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
@@ -45,7 +45,7 @@ public class SubmitterCommandService {
     }
 
     public void approveSubmitter(Long submitterId) {
-        Submitter submitter = submitterRepository.findById(submitterId).orElseThrow();
+        Submitter submitter = submitterRepository.findSubmitterByIdOrThrow(submitterId);
 
         submitter.updateSubmitterState(SubmitterState.APPROVE.getSubmitterState());
 

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     TOKEN_INCORRECT_ERROR(40102, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
-    EMPTY_PRINCIPAL(40103, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+    EMPTY_PRINCIPAL(40103, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    NOT_ADMIN(40104, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),
 
     // 404 Not Found
     NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
     MOIM_SUBMISSION_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
     MOIM_BY_HOST_AND_STATE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
+    SUBMITTER_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "존재하지 않는 호스트 승인 신청입니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -31,9 +31,10 @@ public enum SuccessCode {
     SUBMISSION_DETAIL_GET_SUCCESS(20019, HttpStatus.OK, "신청자에 해당하는 신청 내역 조회 성공"),
     COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20020, HttpStatus.OK, "게스트에 해당하는 참가한 모임 리스트 조회 성공"),
     SUBMITTER_LIST_BY_MOIM_GET_SUCCESS(20021, HttpStatus.OK, "모임에 해당하는 신청자 전체 조회 성공"),
-    SUBMITTER_APPROVE_SUCCESS(20022, HttpStatus.OK, "신청자 승인 성공"),
+    MOIM_SUBMITTER_APPROVE_SUCCESS(20022, HttpStatus.OK, "모임 신청자 승인 성공"),
     MOIM_LIST_BY_HOST(20023, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
     SUBMITTER_LIST_GET_SUCCESS(20024, HttpStatus.OK, "호스트 승인 신청 내역 조회 성공"),
+    HOST_SUBMITTER_APPROVE_SUCCESS(20025, HttpStatus.OK, "호스트 신청자 승인 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #94 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 승인 api를 구현했습니다
     - 승인신청 테이블 승인상태 approve로 변경되도록 하였습니다.
     - host 테이블에 host 정보 생성되도록 하였습니다.
     - 존재하지 않는 승인신청일 경우 예외처리를 진행하였습니다.
     - 
 관리자계정(2개)만 토큰 허용하였습니다.
    - 예외처리를 위해 apiResponse.fail를 사용해보려고했는데 막히기만 하고 응답은 안내려와서 추후 확인해보겠습니다. 우선 pr 올려요! 같이 고민해주세요
    >>처리완료했습니다
   
 ## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-07-17 오후 2 45 46" src="https://github.com/user-attachments/assets/f0ea8030-e819-4e70-8f1a-b11804414f94">

<img width="1470" alt="스크린샷 2024-07-17 오후 2 27 14" src="https://github.com/user-attachments/assets/9219d77b-a45c-4edd-8ed0-457965d4ea11">

![image](https://github.com/user-attachments/assets/b73d700b-06e1-4c4b-a06f-1c9790dbf29d)
