### PR TITLE
[fix] 호스트 신청 내역 전체 조회에 관리자 권한 로직 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -35,8 +35,13 @@ public class SubmitterController implements SubmitterControllerDocs {
     }
 
     @GetMapping("/v1/submitter-list")
-    public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList() {
-        return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS, submitterQueryService.getSubmitterList());
+    public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList(@UserId final Long userId) {
+        if (userId == 4 || userId == 5) {
+            return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS,
+                    submitterQueryService.getSubmitterList());
+        } else {
+            return ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
+        }
     }
 
     @PatchMapping("/v1/submitter/{submitterId}")

--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -36,7 +36,7 @@ public class SubmitterController implements SubmitterControllerDocs {
 
     @GetMapping("/v1/submitter-list")
     public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList(@UserId final Long userId) {
-        if (userId == 4 || userId == 5) {
+        if (userId == 12 || userId == 13) {
             return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS,
                     submitterQueryService.getSubmitterList());
         } else {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #100

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 신청 내역 전체 조회에 관리자 권한 로직 추가
  - 관리자 권한을 가진 userId (소빈, 픽플)일때만 조회할 수 있도록 확인 로직을 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 화이탱

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 테스트는 로컬 DB로 해서 userId == 5일 때 관리자인것으로 테스트했습니다.

<img width="1010" alt="스크린샷 2024-07-17 오후 5 28 27" src="https://github.com/user-attachments/assets/bfff4c97-b57e-448d-82b9-e31c2a0ab220">

<img width="624" alt="스크린샷 2024-07-17 오후 5 34 54" src="https://github.com/user-attachments/assets/8133d617-fcf4-42a7-acda-2ab2611b814f">

<img width="621" alt="스크린샷 2024-07-17 오후 5 35 00" src="https://github.com/user-attachments/assets/c31d4abc-8978-4aa5-97bb-1fe0c3550c80">
