### PR TITLE
[fix] 모임 개설 후 리턴값으로 해당 모임 아이디 반환하도록 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/guest/domain/Guest.java
+++ b/src/main/java/com/pickple/server/api/guest/domain/Guest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -41,6 +42,7 @@ public class Guest extends BaseTimeEntity {
 
     private String nickname;
 
+    @Size(max = 500)
     private String imageUrl;
 
     @Builder

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -4,6 +4,7 @@ import com.pickple.server.api.moim.domain.QuestionInfo;
 import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
+import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
@@ -32,9 +33,10 @@ public class MoimController implements MoimControllerDocs {
     private final MoimCommandService moimCommandService;
 
     @PostMapping("/v1/moim")
-    public ApiResponseDto createMoim(@HostId Long hostId, @RequestBody MoimCreateRequest moimCreateRequest) {
-        moimCommandService.createMoim(hostId, moimCreateRequest);
-        return ApiResponseDto.success(SuccessCode.MOIM_CREATE_SUCCESS);
+    public ApiResponseDto<MoimCreateResponse> createMoim(@HostId Long hostId,
+                                                         @RequestBody MoimCreateRequest moimCreateRequest) {
+        return ApiResponseDto.success(SuccessCode.MOIM_CREATE_SUCCESS,
+                moimCommandService.createMoim(hostId, moimCreateRequest));
     }
 
     @GetMapping("/v1/moim/categories")

--- a/src/main/java/com/pickple/server/api/moim/domain/ImageInfo.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/ImageInfo.java
@@ -1,16 +1,20 @@
 package com.pickple.server.api.moim.domain;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class ImageInfo {
 
+    @Size(max = 500)
     @NotBlank(message = "이미지가 비어있습니다.")
     private String imageUrl1;
 
+    @Size(max = 500)
     private String imageUrl2;
 
+    @Size(max = 500)
     private String imageUrl3;
 
 }

--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -6,6 +6,7 @@ import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.notice.domain.Notice;
 import com.pickple.server.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -63,6 +64,7 @@ public class Moim extends BaseTimeEntity {
 
     private String title;
 
+    @Column(length = 2000)
     private String description;
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimCreateResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimCreateResponse.java
@@ -1,0 +1,9 @@
+package com.pickple.server.api.moim.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MoimCreateResponse(
+        Long moimId
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -5,6 +5,7 @@ import com.pickple.server.api.host.repository.HostRepository;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
+import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +19,7 @@ public class MoimCommandService {
     private final HostRepository hostRepository;
     private final MoimRepository moimRepository;
 
-    public void createMoim(Long hostId, MoimCreateRequest request) {
+    public MoimCreateResponse createMoim(Long hostId, MoimCreateRequest request) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
         Moim moim = Moim.builder()
                 .host(host)
@@ -36,5 +37,8 @@ public class MoimCommandService {
                 .moimState(MoimState.ONGOING.getMoimState())
                 .build();
         moimRepository.save(moim);
+        return MoimCreateResponse.builder()
+                .moimId(moim.getId())
+                .build();
     }
 }

--- a/src/main/java/com/pickple/server/api/notice/domain/Notice.java
+++ b/src/main/java/com/pickple/server/api/notice/domain/Notice.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,6 +35,7 @@ public class Notice extends BaseTimeEntity {
 
     private String title;
 
+    @Size(max = 500)
     private String content;
 
     private String imageUrl;

--- a/src/main/java/com/pickple/server/api/notice/domain/Notice.java
+++ b/src/main/java/com/pickple/server/api/notice/domain/Notice.java
@@ -38,5 +38,6 @@ public class Notice extends BaseTimeEntity {
     @Size(max = 500)
     private String content;
 
+    @Size(max = 500)
     private String imageUrl;
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #102

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 개설 후 리턴값으로 해당 모임 아이디 반환하도록 수정
  - moimId를 반환하는 response를 구현했습니다.
  - 기능명세서에 맞게 엔티티들의 필드 length를 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 클라쌤들이 라우팅 시 필요하다고 요청하셔서 수정했습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="634" alt="스크린샷 2024-07-18 오전 12 56 58" src="https://github.com/user-attachments/assets/43940c11-3b13-4f51-851a-100a8a00a9be">
<img width="962" alt="스크린샷 2024-07-18 오전 12 57 04" src="https://github.com/user-attachments/assets/9859413d-275f-4f0e-b7d3-d010cf1ab70d">
