### PR TITLE
[hotfix] 모임에 해당하는 신청자 전체 조회 시 모임명도 같이 반환하도록 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record MoimSubmissionByMoimResponse(
+        String moimTitle,
         int maxGuest,    //신청자 최대 인원
         Boolean isApprovable,    //승인가능여부
         List<SubmitterInfo> submitterList    //신청자 리스트

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -113,6 +113,7 @@ public class MoimSubmissionQueryService {
 
         return MoimSubmissionByMoimResponse
                 .builder()
+                .moimTitle(moim.getTitle())
                 .maxGuest(moim.getMaxGuest())
                 .isApprovable(isApprovable(moim))
                 .submitterList(submitterInfoList)


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #107 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임에 해당하는 신청자 전체 조회 시 모임명도 같이 반환하도록 수정
  - response에 moimTitle 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 클라에서 해당 API 조회 뷰에서 모임명이 필요하다고 요청하셔서 수정했습니다.
- 급해서 먼저 머지할테니 나중에 리뷰 부탁드립니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="645" alt="스크린샷 2024-07-18 오전 6 29 22" src="https://github.com/user-attachments/assets/42a6c5f7-be4a-4a9f-9395-7afc510bcdb8">
