### PR TITLE
[hotfix] 모임 신청자 승인 시 미승인자 상태 rejected로 변경

### DIFF
--- a/src/main/java/com/pickple/server/api/host/domain/Host.java
+++ b/src/main/java/com/pickple/server/api/host/domain/Host.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -41,6 +42,7 @@ public class Host extends BaseTimeEntity {
 
     private String nickname;
 
+    @Size(max = 500)
     private String imageUrl;
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -6,7 +6,6 @@ import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.notice.domain.Notice;
 import com.pickple.server.global.common.domain.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -62,9 +62,10 @@ public class Moim extends BaseTimeEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     private QuestionInfo questionList;
 
+    @Size(max = 28)
     private String title;
 
-    @Column(length = 2000)
+    @Size(max = 2000)
     private String description;
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -53,7 +53,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
             @PathVariable Long moimId, @PathVariable Long submitterId
     ) {
         return ApiResponseDto.success(SuccessCode.SUBMISSION_DETAIL_GET_SUCCESS,
-                moimSubmissionQueryService.getSubmittionDetail(moimId, submitterId));
+                moimSubmissionQueryService.getSubmissionDetail(moimId, submitterId));
     }
 
     @GetMapping("/v1/guest/{guestId}/completed-moim-list")

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -16,7 +16,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     MoimSubmission findBymoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<MoimSubmission> findByMoimIdAndGuestIdIn(Long moimId, List<Long> submitterIdList);
+    List<MoimSubmission> findBymoimId(Long moimId);
 
     List<MoimSubmission> findMoimListByMoimId(Long moimId);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -43,10 +43,7 @@ public class MoimSubmissionCommandService {
 
     public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findBymoimId(moimId);
-//        for (MoimSubmission moimSubmission : moimSubmissionList) {
-//            moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
-//            moimSubmissionRepository.save(moimSubmission);
-//        }
+
         for (MoimSubmission moimSubmission : moimSubmissionList) {
             if (submitterIdList.contains(moimSubmission.getGuestId())) {
                 moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -42,10 +42,17 @@ public class MoimSubmissionCommandService {
     }
 
     public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findByMoimIdAndGuestIdIn(moimId,
-                submitterIdList);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findBymoimId(moimId);
+//        for (MoimSubmission moimSubmission : moimSubmissionList) {
+//            moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+//            moimSubmissionRepository.save(moimSubmission);
+//        }
         for (MoimSubmission moimSubmission : moimSubmissionList) {
-            moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+            if (submitterIdList.contains(moimSubmission.getGuestId())) {
+                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+            } else {
+                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.REJECTED.getMoimSubmissionState());
+            }
             moimSubmissionRepository.save(moimSubmission);
         }
     }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -60,7 +60,7 @@ public class MoimSubmissionQueryService {
                 .collect(Collectors.toList());
     }
 
-    public SubmittionDetailResponse getSubmittionDetail(Long moimId, Long guestId) {
+    public SubmittionDetailResponse getSubmissionDetail(Long moimId, Long guestId) {
         MoimSubmission submission = moimSubmissionRepository.findBymoimIdAndGuestId(moimId, guestId);
 
         if (submission == null) {

--- a/src/main/java/com/pickple/server/api/submitter/domain/Submitter.java
+++ b/src/main/java/com/pickple/server/api/submitter/domain/Submitter.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,17 +35,21 @@ public class Submitter extends BaseTimeEntity {
     @JoinColumn(name = "guest_id")
     private Guest guest;
 
+    @Size(max = 300)
     private String intro;
 
+    @Size(max = 300)
     private String goal;
 
     private String link;
 
+    @Size(max = 10)
     private String nickname;
 
     @JdbcTypeCode(SqlTypes.JSON)
     private SubmitterCategoryInfo categoryList;
 
+    @Size(max = 300)
     private String plan;
 
     private String email;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #109 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 신청자 승인 시 미승인자의 상태 변경
  - 선택한 신청자 이외의 승인하지 않은 신청자들의 상태를 승인 거절(rejected) 상태가 되도록 수정했습니다.
  - 자잘한 오타를 수정했습니다.
  - 필드 길이 몇개 수정했습니다...
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 보람시축하해용
- 필드 길이 바꾼건 내일 디비 한번 엎을때 반영될 것 같습니다.
## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="628" alt="스크린샷 2024-07-18 오후 6 31 48" src="https://github.com/user-attachments/assets/ec1b1bc0-b598-420b-8b09-0503f06a5aaf">

<img width="1075" alt="스크린샷 2024-07-18 오후 6 31 42" src="https://github.com/user-attachments/assets/91e992a8-2a4d-4677-bc12-71a29d480742">
