### PR TITLE
[hotfix] 게스트 및 호스트 마이 클래스 모임 조회 시 빈 배열 처리 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -9,8 +9,6 @@ import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
-import com.pickple.server.global.exception.CustomException;
-import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.util.DateUtil;
 import java.util.List;
 import java.util.Random;
@@ -97,9 +95,9 @@ public class MoimQueryService {
 
     public List<MoimListByHostGetResponse> getMoimListByHost(Long hostId, String moimState) {
         List<Moim> moimList = moimRepository.findMoimByhostIdAndMoimState(hostId, moimState);
-        if (moimList.isEmpty()) {
-            throw new CustomException(ErrorCode.MOIM_BY_HOST_AND_STATE_NOT_FOUND);
-        }
+//        if (moimList.isEmpty()) {
+//            throw new CustomException(ErrorCode.MOIM_BY_HOST_AND_STATE_NOT_FOUND);
+//        }
         return moimList.stream()
                 .map(oneMoim -> MoimListByHostGetResponse.builder()
                         .moimId(oneMoim.getId())

--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionControllerDocs.java
@@ -38,7 +38,6 @@ public interface MoimSubmissionControllerDocs {
             value = {
                     @ApiResponse(responseCode = "20018", description = "게스트에 해당하는 신청한 모임 리스트 조회 성공"),
                     @ApiResponse(responseCode = "40403", description = "존재하지 않는 게스트입니다."),
-                    @ApiResponse(responseCode = "40406", description = "상태에 맞는 모임이 없습니다.")
             }
     )
     ApiResponseDto getSubmittedMoimListByGuest(
@@ -51,7 +50,7 @@ public interface MoimSubmissionControllerDocs {
             value = {
                     @ApiResponse(responseCode = "20019", description = "신청자에 해당하는 신청 내역 조회 성공"),
                     @ApiResponse(responseCode = "40404", description = "존재하지 않는 모임입니다."),
-                    @ApiResponse(responseCode = "40407", description = "해당 모임에 신청한 내역이 없습니다.")
+                    @ApiResponse(responseCode = "40406", description = "해당 모임에 신청한 내역이 없습니다.")
             }
     )
     ApiResponseDto getSubmissionDetail(
@@ -62,8 +61,7 @@ public interface MoimSubmissionControllerDocs {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "20020", description = "게스트에 해당하는 참가한 모임 리스트 조회 성공"),
-                    @ApiResponse(responseCode = "40403", description = "존재하지 않는 게스트입니다."),
-                    @ApiResponse(responseCode = "40406", description = "상태에 맞는 모임이 없습니다.")
+                    @ApiResponse(responseCode = "40403", description = "존재하지 않는 게스트입니다.")
             }
     )
     ApiResponseDto getCompletedMoimListByGuest(
@@ -74,8 +72,7 @@ public interface MoimSubmissionControllerDocs {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "20021", description = "모임에 해당하는 신청자 전체 조회 성공"),
-                    @ApiResponse(responseCode = "40404", description = "존재하지 않는 모임입니다."),
-                    @ApiResponse(responseCode = "40409", description = "해당 모임에 신청자가 없습니다.")
+                    @ApiResponse(responseCode = "40404", description = "존재하지 않는 모임입니다.")
             }
     )
     ApiResponseDto getSubmitterListByMoim(

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -43,9 +43,9 @@ public class MoimSubmissionQueryService {
             moimSubmissionList = moimSubmissionRepository.findAllByMoimSubmissionState(moimSubmissionState);
         }
 
-        if (moimSubmissionList.isEmpty()) {
-            throw new CustomException(ErrorCode.MOIM_BY_STATE_NOT_FOUND);
-        }
+//        if (moimSubmissionList.isEmpty()) {
+//            throw new CustomException(ErrorCode.MOIM_BY_STATE_NOT_FOUND);
+//        }
 
         return moimSubmissionList.stream()
                 .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()
@@ -78,9 +78,9 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findCompletedMoimSubmissionsByGuest(
                 guest.getId());
 
-        if (moimSubmissionList.isEmpty()) {
-            throw new CustomException(ErrorCode.MOIM_BY_STATE_NOT_FOUND);
-        }
+//        if (moimSubmissionList.isEmpty()) {
+//            throw new CustomException(ErrorCode.MOIM_BY_STATE_NOT_FOUND);
+//        }
 
         return moimSubmissionList.stream()
                 .map(oneMoimSubmission -> SubmittedMoimByGuestResponse.builder()

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -32,10 +32,10 @@ public enum ErrorCode {
     GUEST_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "존재하지 않는 게스트입니다"),
     MOIM_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     HOST_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다"),
-    MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
-    MOIM_SUBMISSION_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
-    MOIM_BY_HOST_AND_STATE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
-    SUBMITTER_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "존재하지 않는 호스트 승인 신청입니다."),
+    //MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
+    MOIM_SUBMISSION_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
+    //MOIM_BY_HOST_AND_STATE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
+    SUBMITTER_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "존재하지 않는 호스트 승인 신청입니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #111

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게스트 및 호스트 마이 클래스 모임 조회 시 빈 배열 처리 로직 수정
  - 모임 리스트가 비어있을 때 에러처리를 빼고 빈 배열로 반환하도록 수정했습니다
  - 에러 코드 삭제했습니다.
  - Swagger 명세서 수정했습니다. 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 급해서 먼저 머지하겠습니다. 추후 리뷰 부탁드립니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 게스트 신청한 모임 조회
<img width="635" alt="스크린샷 2024-07-18 오후 10 48 28" src="https://github.com/user-attachments/assets/c352d35c-910c-4e1b-bb6a-c2d95d6fdd99">

- 게스트 참여한 모임 조회
<img width="631" alt="스크린샷 2024-07-18 오후 10 49 06" src="https://github.com/user-attachments/assets/ac890edd-9139-450a-96c4-b5336a6dcf2a">


- 호스트 모임 조회
<img width="630" alt="스크린샷 2024-07-18 오후 10 53 23" src="https://github.com/user-attachments/assets/f88cbf3e-d6bd-46e9-87f3-c331700e1b9c">
