### PR TITLE
[hotfix] 모임 참여 신청 시 기본 상태값 변경

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, Long> {
-    boolean existsByMoimAndMoimSubmissionStateAndGuestId(Moim moim, String moimSubmissionState, Long guestId);
+    boolean existsByMoimAndGuestId(Moim moim, Long guestId);
 
     List<MoimSubmission> findAllByGuestId(Long guestId);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -28,15 +28,15 @@ public class MoimSubmissionCommandService {
                 .moim(moim)
                 .answerList(request.answerList())
                 .accountList(request.accountList())
-                .moimSubmissionState(MoimSubmissionState.PENDING_PAYMENT.getMoimSubmissionState())
+                .moimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())
                 .build();
         isDuplicatedMoimSubmission(moimSubmission);
         moimSubmissionRepository.save(moimSubmission);
     }
 
     private void isDuplicatedMoimSubmission(MoimSubmission moimSubmission) {
-        if (moimSubmissionRepository.existsByMoimAndMoimSubmissionStateAndGuestId(moimSubmission.getMoim(),
-                moimSubmission.getMoimSubmissionState(), moimSubmission.getGuestId())) {
+        if (moimSubmissionRepository.existsByMoimAndGuestId(moimSubmission.getMoim(),
+                moimSubmission.getGuestId())) {
             throw new BadRequestException(ErrorCode.DUPLICATION_MOIM_SUBMISSION);
         }
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #114 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 참여 신청 시 기본 상태값 변경
  - pendingPayment -> pendingApproval로 기본 상태값을 변경했습니다.
  - 중복 모임 신청 로직을 수정했습니다. 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재 입금 대기 상태에서 승인 대기 상태로 바꾸는 API가 없어서 일단 앱잼에서는 바로 승인 대기 상태로 지정해주기로 했습니다.
- 중복 모임 신청 로직의 경우 상태값이 다르면 중복으로 들어가는 이슈가 있어서 moimId랑 guestId 값만 비교하는 로직으로 수정했습니다.
- 추후에 리뷰 부탁드립니다.
## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 모임 참여
<img width="629" alt="스크린샷 2024-07-19 오전 12 03 45" src="https://github.com/user-attachments/assets/a915fe45-707a-473c-9cb8-017b8c8341ae">
<img width="1118" alt="스크린샷 2024-07-19 오전 12 04 29" src="https://github.com/user-attachments/assets/a8d4da91-e66a-4275-bcfc-333c101a9b33">

- 중복 신청 시 예외처리
<img width="630" alt="스크린샷 2024-07-19 오전 12 03 53" src="https://github.com/user-attachments/assets/2c8b42b4-da48-46f5-8cc9-22ab88c8daa6">


