### PR TITLE
[hotfix] 이미지 없이 모임 생성되는 오류 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -16,6 +16,7 @@ import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +35,7 @@ public class MoimController implements MoimControllerDocs {
 
     @PostMapping("/v1/moim")
     public ApiResponseDto<MoimCreateResponse> createMoim(@HostId Long hostId,
-                                                         @RequestBody MoimCreateRequest moimCreateRequest) {
+                                                         @Validated @RequestBody MoimCreateRequest moimCreateRequest) {
         return ApiResponseDto.success(SuccessCode.MOIM_CREATE_SUCCESS,
                 moimCommandService.createMoim(hostId, moimCreateRequest));
     }

--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -15,6 +15,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +70,8 @@ public class Moim extends BaseTimeEntity {
     @Size(max = 2000)
     private String description;
 
+    @Valid
+    @NotNull
     @JdbcTypeCode(SqlTypes.JSON)
     private ImageInfo imageList;
 

--- a/src/main/java/com/pickple/server/api/moim/dto/request/MoimCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/request/MoimCreateRequest.java
@@ -6,12 +6,13 @@ import com.pickple.server.api.moim.domain.ImageInfo;
 import com.pickple.server.api.moim.domain.QuestionInfo;
 import com.pickple.server.api.moimsubmission.domain.AccountInfo;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record MoimCreateRequest(
         CategoryInfo categoryList,
 
-        @NotBlank(message = "오프라인 여부가 비어있습니다")
+        @NotNull(message = "오프라인 여부가 비어있습니다")
         boolean isOffline,
 
         @NotBlank(message = "모임 장소가 비어있습니다.")
@@ -19,10 +20,10 @@ public record MoimCreateRequest(
 
         DateInfo dateList,
 
-        @NotBlank(message = "모임 정원이 비어있습니다.")
+        @NotNull(message = "모임 정원이 비어있습니다.")
         int maxGuest,
 
-        @NotBlank(message = "참가비가 비어있습니다.")
+        @NotNull(message = "참가비가 비어있습니다.")
         int fee,
 
         AccountInfo accountList,


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #112

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이미지 없이 모임이 생성되는 오류 수정
  - @Validated와 @Notblank 어노테이션을 사용하여 ImageUrl1이 없을 때 모임이 생성되지 않도록 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 보람살려줘 화이팅
- 추후 리뷰 부탁드립니다.
## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="625" alt="스크린샷 2024-07-19 오전 2 09 52" src="https://github.com/user-attachments/assets/c632771f-db9f-408f-ab6e-73b67f62c8dc">
<img width="634" alt="스크린샷 2024-07-19 오전 2 09 39" src="https://github.com/user-attachments/assets/a2f87e79-a68e-48fe-b869-e3e4119440f5">
