### PR TITLE
[hotfix] 신청자 승인 시 승인 대기 상태만 승인 가능하도록 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/domain/SubmitterInfo.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/domain/SubmitterInfo.java
@@ -4,6 +4,7 @@ public record SubmitterInfo(
         Long submitterId,    //guest id
         String nickname,    //신청자 닉네임
         String submitterImageUrl,   //신청자 프로필 이미지
-        String submittedDate    //신청한 날짜 및 시간
+        String submittedDate,    //신청한 날짜 및 시간
+        String state //신청 상태
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -14,11 +14,14 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     List<MoimSubmission> findAllByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
 
-    MoimSubmission findBymoimIdAndGuestId(Long moimId, Long guestId);
+    MoimSubmission findByMoimIdAndGuestId(Long moimId, Long guestId);
 
     List<MoimSubmission> findBymoimId(Long moimId);
 
     List<MoimSubmission> findMoimListByMoimId(Long moimId);
+
+    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected')")
+    List<MoimSubmission> findMoimListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -46,7 +46,11 @@ public class MoimSubmissionCommandService {
 
         for (MoimSubmission moimSubmission : moimSubmissionList) {
             if (submitterIdList.contains(moimSubmission.getGuestId())) {
-                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+                //신청자 상태가 승인 대기(pendingApproval)일 때 승인
+                if (moimSubmission.getMoimSubmissionState()
+                        .equals(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())) {
+                    moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
+                }
             } else {
                 moimSubmission.updateMoimSubmissionState(MoimSubmissionState.REJECTED.getMoimSubmissionState());
             }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -28,7 +28,7 @@ public class MoimSubmissionCommandService {
                 .moim(moim)
                 .answerList(request.answerList())
                 .accountList(request.accountList())
-                .moimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())
+                .moimSubmissionState(MoimSubmissionState.PENDING_PAYMENT.getMoimSubmissionState())
                 .build();
         isDuplicatedMoimSubmission(moimSubmission);
         moimSubmissionRepository.save(moimSubmission);

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -95,11 +95,6 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimIdAndMoimSubmissionState(
                 moimId);
 
-        // guestId를 추출하여 리스트에 저장
-//        List<Long> guestIdList = moimSubmissionList.stream()
-//                .map(MoimSubmission::getGuestId)
-//                .toList();
-
         // guestId를 이용하여 SubmitterInfo 객체 생성 후 리스트에 저장
         List<SubmitterInfo> submitterInfoList = moimSubmissionList.stream()
                 .map(moimSubmission -> getSubmitterInfo(moimSubmission.getGuestId(), moimId))

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -58,7 +58,7 @@ public class MoimSubmissionQueryService {
     }
 
     public SubmittionDetailResponse getSubmissionDetail(Long moimId, Long guestId) {
-        MoimSubmission submission = moimSubmissionRepository.findBymoimIdAndGuestId(moimId, guestId);
+        MoimSubmission submission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
 
         if (submission == null) {
             throw new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND);
@@ -92,17 +92,18 @@ public class MoimSubmissionQueryService {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
 
         // moimSubmissionList 가져오기
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimIdAndMoimSubmissionState(
+                moimId);
 
         // guestId를 추출하여 리스트에 저장
-        List<Long> guestIdList = moimSubmissionList.stream()
-                .map(MoimSubmission::getGuestId)
-                .toList();
+//        List<Long> guestIdList = moimSubmissionList.stream()
+//                .map(MoimSubmission::getGuestId)
+//                .toList();
 
         // guestId를 이용하여 SubmitterInfo 객체 생성 후 리스트에 저장
-        List<SubmitterInfo> submitterInfoList = guestIdList.stream()
-                .map(this::getSubmitterInfo)
-                .toList();
+        List<SubmitterInfo> submitterInfoList = moimSubmissionList.stream()
+                .map(moimSubmission -> getSubmitterInfo(moimSubmission.getGuestId(), moimId))
+                .collect(Collectors.toList());
 
         return MoimSubmissionByMoimResponse
                 .builder()
@@ -111,7 +112,6 @@ public class MoimSubmissionQueryService {
                 .isApprovable(isApprovable(moim))
                 .submitterList(submitterInfoList)
                 .build();
-
     }
 
     private boolean isApprovable(Moim moim) {
@@ -129,17 +129,21 @@ public class MoimSubmissionQueryService {
         return now.isAfter(deadline);
     }
 
-    public SubmitterInfo getSubmitterInfo(Long guestId) {
+    public SubmitterInfo getSubmitterInfo(Long guestId, Long moimId) {
         // Guest 객체를 가져옴
         Guest guest = guestRepository.findById(guestId)
                 .orElseThrow(() -> new CustomException(ErrorCode.GUEST_NOT_FOUND));
+
+        //MoimSubmission 객체를 가져옴
+        MoimSubmission moimSubmission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
 
         // SubmitterInfo 객체 생성
         return new SubmitterInfo(
                 guest.getId(),
                 guest.getNickname(),
                 guest.getImageUrl(),
-                DateTimeUtil.refineDateAndTime(guest.getCreatedAt())
+                DateTimeUtil.refineDateAndTime(guest.getCreatedAt()),
+                moimSubmission.getMoimSubmissionState()
         );
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #118 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 신청자 승인 시 승인 대기 상태만 승인 가능하도록 로직 수정
  - 모임 신청 생성 시 기본값을 다시 pendingPayment로 수정했습니다.(이해를 똑바로 못한 휴먼에러이슈)
  - 신청자 승인 시 pendingApproval (승인 대기)일 때만 승인할 수 있도록 로직을 수정했습니다.
  - 신청자 리스트 조회 시 특정 상태만 조회하도록 (승인 대기, 승인 완료, 승인 거부) 수정했습니다.
  - 신청자 리스트 조회 시 개별 신청자의 현재 모임신청 상태를 같이 반환하도록 수정했습니다.
 
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 특정 상태만 조회하도록 바꾼 이유는 클라에서 승인이 가능하거나 또는 승인 완료, 승인 거절하는 케이스만 실질적으로 필요하다고 말씀해주셔서 수정했습니다.
- 모임 신청 상태값은 승인 후 다시 신청자 관리 뷰로 들어갔을 때 체크박스 표시를 위해 필요하다고 말씀해주셔서 추가했습니다.
- 시간되실 때 리뷰 부탁드립니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 상태 같이 반환
<img width="629" alt="스크린샷 2024-07-19 오전 4 26 23" src="https://github.com/user-attachments/assets/7f6194bc-ced7-4551-80c8-0edecf2700d5">

- 승인 대기 상태일때만 승인 가능
<img width="632" alt="스크린샷 2024-07-19 오전 4 45 01" src="https://github.com/user-attachments/assets/6e10dec2-098c-45eb-9458-d95abf5f0294">

<img width="1111" alt="스크린샷 2024-07-19 오전 4 44 39" src="https://github.com/user-attachments/assets/57f29ff6-5747-48a8-8328-e2480aeb0654">
<img width="1120" alt="스크린샷 2024-07-19 오전 4 44 50" src="https://github.com/user-attachments/assets/3eb1e10e-6433-4aa1-92dd-22e4e67753ff">

- 모임의 특정 상태값만 조회 (pendingApproval, approved, rejected)
<img width="634" alt="스크린샷 2024-07-19 오전 4 47 05" src="https://github.com/user-attachments/assets/8a6a4d25-d0f8-436e-80e8-847775c257e3">
