### PR TITLE
[hotfix] 모임 신청자 관련 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -15,7 +15,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
@@ -70,7 +69,6 @@ public class Moim extends BaseTimeEntity {
     @Size(max = 2000)
     private String description;
 
-    @Valid
     @NotNull
     @JdbcTypeCode(SqlTypes.JSON)
     private ImageInfo imageList;

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -7,6 +7,8 @@ import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +38,9 @@ public class MoimCommandService {
                 .imageList(request.imageList())
                 .moimState(MoimState.ONGOING.getMoimState())
                 .build();
+        if (moim.getImageList().getImageUrl1() == null) {
+            throw new CustomException(ErrorCode.MISSING_IMAGE_URL);
+        }
         moimRepository.save(moim);
         return MoimCreateResponse.builder()
                 .moimId(moim.getId())

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/response/MoimSubmissionByMoimResponse.java
@@ -1,14 +1,22 @@
 package com.pickple.server.api.moimsubmission.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.pickple.server.api.moimsubmission.domain.SubmitterInfo;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record MoimSubmissionByMoimResponse(
         String moimTitle,
+
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDate moimDate,
         int maxGuest,    //신청자 최대 인원
         Boolean isApprovable,    //승인가능여부
+
+        boolean isMoimSubmissionApproved,
+        boolean isOngoing,
         List<SubmitterInfo> submitterList    //신청자 리스트
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -6,7 +6,7 @@ import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
 import com.pickple.server.api.moimsubmission.dto.request.MoimSubmitRequest;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
-import com.pickple.server.global.exception.BadRequestException;
+import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class MoimSubmissionCommandService {
     private void isDuplicatedMoimSubmission(MoimSubmission moimSubmission) {
         if (moimSubmissionRepository.existsByMoimAndGuestId(moimSubmission.getMoim(),
                 moimSubmission.getGuestId())) {
-            throw new BadRequestException(ErrorCode.DUPLICATION_MOIM_SUBMISSION);
+            throw new CustomException(ErrorCode.DUPLICATION_MOIM_SUBMISSION);
         }
     }
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -14,6 +14,7 @@ import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.util.DateTimeUtil;
+import com.pickple.server.global.util.DateUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -103,8 +104,11 @@ public class MoimSubmissionQueryService {
         return MoimSubmissionByMoimResponse
                 .builder()
                 .moimTitle(moim.getTitle())
+                .moimDate(moim.getDateList().getDate())
                 .maxGuest(moim.getMaxGuest())
                 .isApprovable(isApprovable(moim))
+                .isMoimSubmissionApproved(isMoimSubmissonApproved(moimId))
+                .isOngoing(isOngoing(moimId))
                 .submitterList(submitterInfoList)
                 .build();
     }
@@ -140,5 +144,24 @@ public class MoimSubmissionQueryService {
                 DateTimeUtil.refineDateAndTime(guest.getCreatedAt()),
                 moimSubmission.getMoimSubmissionState()
         );
+    }
+
+    public boolean isMoimSubmissonApproved(Long moimId) {
+        Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
+
+        //모임에 해당하는 신청 내역 중 approved가 있는 경우 true 리턴
+        for (MoimSubmission moimSubmission : moimSubmissionList) {
+            if (moimSubmission.getMoimSubmissionState().equals(MoimSubmissionState.APPROVED.getMoimSubmissionState())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isOngoing(Long moimId) {
+        Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
+        int day = DateUtil.calculateCompletedDay(moim.getDateList().getDate());
+        return day > 0;
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_PARAMETER(40006, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
     DUPLICATION_MOIM_SUBMISSION(40007, HttpStatus.BAD_REQUEST, "이미 대기중인 모임입니다."),
     DUPLICATION_HOST_NICKNAME(40008, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    MISSING_IMAGE_URL(40009, HttpStatus.BAD_REQUEST, "필수 이미지가 없습니다."),
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),

--- a/src/main/java/com/pickple/server/global/util/DateUtil.java
+++ b/src/main/java/com/pickple/server/global/util/DateUtil.java
@@ -11,4 +11,9 @@ public class DateUtil {
         return dday;
     }
 
+    public static int calculateCompletedDay(LocalDate date) {
+        LocalDate today = LocalDate.now();
+        int day = (int) ChronoUnit.DAYS.between(today, date);
+        return day;
+    }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #116 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 신청자 관련 로직 수정
  - 필수 이미지 없을 때 에러 던지도록 로직 수정했습니다.
  - 모임에 해당하는 신청자 전체 조회 response에 승인 여부와 현재 진행중인 모임인지 여부에 대한 필드값을 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 모임 엔티티에서 @Valid 쓰니까 다른 post 요청까지 다 막히는 에러가 생겨서 이 부분은 앱잼 이후에 좀 더 공부해보고 수정해보겠습니다.
- 급해서 먼저 머지합니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="625" alt="스크린샷 2024-07-19 오후 5 23 51" src="https://github.com/user-attachments/assets/2dee6f70-3262-435b-addf-33f0e4bca501">
