### PR TITLE
[fix] 호스트 마이페이지 500 에러 해결

### DIFF
--- a/src/main/java/com/pickple/server/global/common/annotation/resolver/HostIdResolver.java
+++ b/src/main/java/com/pickple/server/global/common/annotation/resolver/HostIdResolver.java
@@ -36,6 +36,9 @@ public class HostIdResolver implements HandlerMethodArgumentResolver {
             throw new CustomException(ErrorCode.EMPTY_PRINCIPAL);
         }
         Host host = hostRepository.findHostByUserId(Long.valueOf(principal.getName()));
+        if (host == null) {
+            throw new CustomException(ErrorCode.HOST_NOT_FOUND);
+        }
         return host.getId();
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -33,9 +33,7 @@ public enum ErrorCode {
     GUEST_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "존재하지 않는 게스트입니다"),
     MOIM_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     HOST_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다"),
-    //MOIM_BY_STATE_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "상태에 맞는 모임이 없습니다"),
     MOIM_SUBMISSION_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
-    //MOIM_BY_HOST_AND_STATE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트와 상태에 해당하는 모임이 없습니다."),
     SUBMITTER_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "존재하지 않는 호스트 승인 신청입니다."),
 
     // 405 Method Not Allowed Error


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #121 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 마이페이지 500에러 해결
  - HostIdResolver에 host가 null 일 때의 예외처리를 진행해주었습니다.
https://github.com/PICK-PLE/PICKPLE-server/blob/64224f1dd7b6fdf5999c2d2edbff9213c9de4a26/src/main/java/com/pickple/server/global/common/annotation/resolver/HostIdResolver.java#L29-L43

  - ErrorCode의 불필요 주석을 삭제했습니다.
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 요상한거 있으면 말해주세용
- 보람찌 얼른와잉

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="625" alt="스크린샷 2024-08-02 오후 5 25 02" src="https://github.com/user-attachments/assets/22027241-1518-474f-9dff-fde5e53a2011">
