### PR TITLE
[feat] requestDto에 RedirectUri 담도록 구현

### DIFF
--- a/src/main/java/com/pickple/server/global/auth/client/dto/UserLoginRequest.java
+++ b/src/main/java/com/pickple/server/global/auth/client/dto/UserLoginRequest.java
@@ -2,11 +2,15 @@ package com.pickple.server.global.auth.client.dto;
 
 import com.pickple.server.api.user.domain.SocialType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record UserLoginRequest(
-        @NotNull(message = "소셜 로그인 종류가 입력되지 않았습니다.")
+        @NotBlank(message = "소셜 로그인 종류가 입력되지 않았습니다.")
         @Schema(description = "소셜로그인 타입", example = "KAKAO")
-        SocialType socialType
+        SocialType socialType,
+
+        @NotBlank
+        @Schema(description = "리다이텍트 uri 값", example = "https://pick-ple.com/kakao/redirection or http://localhost:5173/kakao/redirection")
+        String redirectUri
 ) {
 }

--- a/src/main/java/com/pickple/server/global/auth/client/kakao/KakaoSocialService.java
+++ b/src/main/java/com/pickple/server/global/auth/client/kakao/KakaoSocialService.java
@@ -21,13 +21,11 @@ import org.springframework.stereotype.Service;
 public class KakaoSocialService implements SocialService {
 
     private static final String AUTH_CODE = "authorization_code";
-    private static final String REDIRECT_URI = "http://localhost:5173/kakao/redirection";
 
     @Value("${kakao.clientId}")
     private String clientId;
     private final KakaoApiClient kakaoApiClient;
     private final KakaoAuthApiClient kakaoAuthApiClient;
-
 
     @Transactional
     @Override
@@ -38,7 +36,7 @@ public class KakaoSocialService implements SocialService {
         String accessToken;
         try {
             // 인가 코드로 Access Token + Refresh Token 받아오기
-            accessToken = getOAuth2Authentication(authorizationCode);
+            accessToken = getOAuth2Authentication(authorizationCode, loginRequest.redirectUri());
         } catch (FeignException e) {
             throw new CustomException(ErrorCode.AUTHENTICATION_CODE_EXPIRED);
         }
@@ -47,12 +45,13 @@ public class KakaoSocialService implements SocialService {
     }
 
     private String getOAuth2Authentication(
-            final String authorizationCode
+            final String authorizationCode,
+            final String redirectUri
     ) {
         KakaoAccessTokenResponse response = kakaoAuthApiClient.getOAuth2AccessToken(
                 AUTH_CODE,
                 clientId,
-                REDIRECT_URI,
+                redirectUri,
                 authorizationCode
         );
         return response.accessToken();


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #124 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
현재는 Redirect Uri를 서버에서 관리해서 클라쌤들이 배포환경과 로컬환경이 분리가 안되고 있었습니다.
RequstDto에 담아 보내는 방식을 통해 환경을 분리하실 수 있도록 하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
클라쌤들이 v1까지 박아놓으셨다고해서 빠른 대응을 위해 기존 엔드포인트를 그대로(v1)으로 가져갔는데요? 
추후 2차 스프린트에서 수정되는 api들은 v2로 변경하며 작업하는 것이 엔드포인트에 버전 정보를 담는 의미가 있다고 생각됩니다.
하지만 이렇게 진행할 경우 클라이언트단에서 에러가 발생합니다.
이번(2차) 스프린트가 끝나고는 운영서버 / 개발서버를 분리하는 작업을 우선시하여 다음(3차) 스프린트부턴 그런 에러가 발생하지 않도록 하면 될 것 같습니다.

해당내용 + 해당 Pr내용은 머지 후 슬랙에 남겨 클라쌤들한테도 말씀드리겠습니다
## 📬 Postman
![스크린샷 2024-08-11 오전 3 51 57](https://github.com/user-attachments/assets/09a20718-e48c-4ac2-b9b3-86c00537bbdf)

