### PR TITLE
[refactor] 카테고리 조회 로직 위치 변경

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -1,7 +1,6 @@
 package com.pickple.server.api.moim.controller;
 
 import com.pickple.server.api.moim.domain.QuestionInfo;
-import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
@@ -42,7 +41,7 @@ public class MoimController implements MoimControllerDocs {
 
     @GetMapping("/v1/moim/categories")
     public ApiResponseDto<List<String>> getAllCategories() {
-        return ApiResponseDto.success(SuccessCode.ALL_CATEGORY_GET_SUCCESS, Category.getCategories());
+        return ApiResponseDto.success(SuccessCode.ALL_CATEGORY_GET_SUCCESS, moimQueryService.getCategories());
     }
 
     @GetMapping("/v1/moim/{moimId}")

--- a/src/main/java/com/pickple/server/api/moim/domain/enums/Category.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/enums/Category.java
@@ -1,8 +1,5 @@
 package com.pickple.server.api.moim.domain.enums;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -31,10 +28,4 @@ public enum Category {
     LANGUAGE("language");
 
     public final String category;
-
-    public static List<String> getCategories() {
-        return Arrays.stream(Category.values())
-                .map(category -> category.category)
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -2,6 +2,7 @@ package com.pickple.server.api.moim.service;
 
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moim.domain.QuestionInfo;
+import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
@@ -10,6 +11,7 @@ import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
 import com.pickple.server.global.util.DateUtil;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -114,5 +116,11 @@ public class MoimQueryService {
             // 테이블이 존재하지 않아서 발생한 예외일 경우 0 반환
             return 0L;
         }
+    }
+
+    public List<String> getCategories() {
+        return Arrays.stream(Category.values())
+                .map(category -> category.category)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #129

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 카테고리 조회 로직 위치 변경
  - 기존 카테고리 enum 내에 있었던 조회 로직을 서비스단으로 이동시켰습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 리드회의화이팅

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="623" alt="스크린샷 2024-08-12 오전 12 13 43" src="https://github.com/user-attachments/assets/5680e774-8161-4f9b-b94d-1f77d095b5a1">
