### PR TITLE
[refactor] 신청자 승인 시 상태값 변경 로직 리팩토링

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -52,14 +52,13 @@ public class MoimSubmissionCommandService {
                     moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
                 }
             }
-            moimSubmissionRepository.save(moimSubmission);
-        }
-        //승인 이후에 승인 대기(pendingApproval)인 요청에 대해 승인 거절(rejected)상태로 변경
-        for (MoimSubmission moimSubmission : moimSubmissionList) {
+
+            //승인 이후에 승인 대기(pendingApproval)인 요청에 대해 승인 거절(rejected)상태로 변경
             if (moimSubmission.getMoimSubmissionState()
                     .equals(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())) {
                 moimSubmission.updateMoimSubmissionState(MoimSubmissionState.REJECTED.getMoimSubmissionState());
             }
+            moimSubmissionRepository.save(moimSubmission);
         }
     }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -51,10 +51,15 @@ public class MoimSubmissionCommandService {
                         .equals(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())) {
                     moimSubmission.updateMoimSubmissionState(MoimSubmissionState.APPROVED.getMoimSubmissionState());
                 }
-            } else {
-                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.REJECTED.getMoimSubmissionState());
             }
             moimSubmissionRepository.save(moimSubmission);
+        }
+        //승인 이후에 승인 대기(pendingApproval)인 요청에 대해 승인 거절(rejected)상태로 변경
+        for (MoimSubmission moimSubmission : moimSubmissionList) {
+            if (moimSubmission.getMoimSubmissionState()
+                    .equals(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState())) {
+                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.REJECTED.getMoimSubmissionState());
+            }
         }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #131 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 신청자 승인 시 상태값 변경 로직 리팩토링
  - 신청자 승인 이후 승인 대기(pendingApproval) 상태인 요청을 검사하여 해당 요청들만 rejected로 바뀌도록 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 일타강사김보람

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 둘다 pendingApproval 상태에서 하나만 승인했을 때
<img width="1378" alt="스크린샷 2024-08-12 오후 5 01 33" src="https://github.com/user-attachments/assets/6081c46a-55c2-4b61-ac45-8fd463bf5ae2">

- 하나만 pendingApproval 상태에서 정상적으로 승인되었을 때 (pendingPayment는 변화 없음)
<img width="1374" alt="스크린샷 2024-08-12 오후 5 02 06" src="https://github.com/user-attachments/assets/f716f4d4-b183-4134-b638-ae3e48addc85">
