### PR TITLE
[refactor] 관리자권한 관리 방식 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
+++ b/src/main/java/com/pickple/server/api/submitter/controller/SubmitterController.java
@@ -7,7 +7,6 @@ import com.pickple.server.api.submitter.service.SubmitterQueryService;
 import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
-import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.response.enums.SuccessCode;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -37,22 +36,14 @@ public class SubmitterController implements SubmitterControllerDocs {
 
     @GetMapping("/v1/submitter-list")
     public ApiResponseDto<List<SubmitterListGetResponse>> getSubmitterList(@UserId final Long userId) {
-        if (userId == 1 || userId == 2) {
-            return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS,
-                    submitterQueryService.getSubmitterList());
-        } else {
-            return ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
-        }
+        return ApiResponseDto.success(SuccessCode.SUBMITTER_LIST_GET_SUCCESS,
+                submitterQueryService.getSubmitterList());
     }
 
     @PatchMapping("/v1/submitter/{submitterId}")
     public ApiResponseDto approveSubmitter(@PathVariable("submitterId") final Long submitterId,
                                            @UserId final Long userId) {
-        if (userId == 1 || userId == 2) {
-            submitterCommandService.approveSubmitter(submitterId);
-            return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
-        } else {
-            return ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
-        }
+        submitterCommandService.approveSubmitter(submitterId);
+        return ApiResponseDto.success(SuccessCode.HOST_SUBMITTER_APPROVE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
@@ -10,6 +10,7 @@ import com.pickple.server.api.submitter.domain.Submitter;
 import com.pickple.server.api.submitter.domain.SubmitterState;
 import com.pickple.server.api.submitter.dto.request.SubmitterCreateRequest;
 import com.pickple.server.api.submitter.repository.SubmitterRepository;
+import com.pickple.server.api.user.domain.Role;
 import com.pickple.server.global.exception.BadRequestException;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
@@ -54,6 +55,9 @@ public class SubmitterCommandService {
                 .category2(submitter.getCategoryList().getCategory2())
                 .category3(submitter.getCategoryList().getCategory3())
                 .build();
+
+        //호스트 승인 시 role host로 변경
+        submitter.getGuest().getUser().updateRole(Role.HOST.getRole());
 
         Host host = Host.builder()
                 .categoryList(hostCategoryInfo)

--- a/src/main/java/com/pickple/server/api/user/domain/Role.java
+++ b/src/main/java/com/pickple/server/api/user/domain/Role.java
@@ -1,0 +1,14 @@
+package com.pickple.server.api.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+    ADMIN("admin"),
+    HOST("host"),
+    GUEST("guest");
+
+    private final String role;
+}

--- a/src/main/java/com/pickple/server/api/user/domain/User.java
+++ b/src/main/java/com/pickple/server/api/user/domain/User.java
@@ -37,6 +37,10 @@ public class User extends BaseTimeEntity {
 
     private String role;
 
+    public void updateRole(String role) {
+        this.role = role;
+    }
+
     public static User of(
             final Long socialId,
             final String email,

--- a/src/main/java/com/pickple/server/api/user/domain/User.java
+++ b/src/main/java/com/pickple/server/api/user/domain/User.java
@@ -35,17 +35,21 @@ public class User extends BaseTimeEntity {
 
     private String socialNickname;
 
+    private String role;
+
     public static User of(
             final Long socialId,
             final String email,
             final SocialType socialType,
-            final String socialNickname
+            final String socialNickname,
+            final String role
     ) {
         return User.builder()
                 .socialId(socialId)
                 .email(email)
                 .socialType(socialType)
                 .socialNickname(socialNickname)
+                .role(role)
                 .build();
     }
 }

--- a/src/main/java/com/pickple/server/api/user/service/UserService.java
+++ b/src/main/java/com/pickple/server/api/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
 import com.pickple.server.api.host.domain.Host;
 import com.pickple.server.api.host.repository.HostRepository;
+import com.pickple.server.api.user.domain.Role;
 import com.pickple.server.api.user.domain.SocialType;
 import com.pickple.server.api.user.domain.User;
 import com.pickple.server.api.user.dto.AccessTokenGetSuccess;
@@ -66,7 +67,8 @@ public class UserService {
                 userResponse.socialId(),
                 userResponse.email(),
                 userResponse.socialType(),
-                userResponse.socialNickname()
+                userResponse.socialNickname(),
+                Role.GUEST.getRole()
         );
         return userRepository.save(user);
     }

--- a/src/main/java/com/pickple/server/api/user/service/UserService.java
+++ b/src/main/java/com/pickple/server/api/user/service/UserService.java
@@ -20,7 +20,10 @@ import com.pickple.server.global.auth.security.UserAuthentication;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -99,7 +102,15 @@ public class UserService {
         if (!userId.equals(tokenService.findIdByRefreshToken(refreshToken))) {
             throw new CustomException(ErrorCode.TOKEN_INCORRECT_ERROR);
         }
-        UserAuthentication userAuthentication = new UserAuthentication(userId, null, null);
+
+        // 사용자 정보 가져오기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 사용자 역할을 기반으로 권한 설정
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+        UserAuthentication userAuthentication = new UserAuthentication(userId.toString(), null, authorities);
+
         return AccessTokenGetSuccess.of(
                 jwtTokenProvider.issueAccessToken(userAuthentication)
         );
@@ -108,7 +119,14 @@ public class UserService {
     public TokenDto getTokenByUserId(
             final Long id
     ) {
-        UserAuthentication userAuthentication = new UserAuthentication(id, null, null);
+        // 사용자 정보 가져오기
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 사용자 역할을 기반으로 권한 설정
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+        UserAuthentication userAuthentication = new UserAuthentication(id.toString(), null, authorities);
+
         String refreshToken = jwtTokenProvider.issueRefreshToken(userAuthentication);
         tokenService.saveRefreshToken(id, refreshToken);
         return TokenDto.of(

--- a/src/main/java/com/pickple/server/global/auth/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/pickple/server/global/auth/security/CustomAccessDeniedHandler.java
@@ -1,5 +1,8 @@
 package com.pickple.server.global.auth.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pickple.server.global.response.ApiResponseDto;
+import com.pickple.server.global.response.enums.ErrorCode;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,13 +13,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
         setResponse(response);
     }
 
-    private void setResponse(HttpServletResponse response) {
+    private void setResponse(HttpServletResponse response) throws IOException {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // ApiResponseDto를 사용해 에러 응답 생성
+        ApiResponseDto<?> apiResponse = ApiResponseDto.fail(ErrorCode.NOT_ADMIN);
+
+        // JSON 응답으로 전송
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }
 }

--- a/src/main/java/com/pickple/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/pickple/server/global/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.requestMatchers("/api/v1/submitter-list", "/api/v1/submitter/*").hasRole("admin");
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     TOKEN_INCORRECT_ERROR(40102, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
     EMPTY_PRINCIPAL(40103, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    NOT_ADMIN(40104, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),
+
+    //403 Forbidden
+    NOT_ADMIN(40301, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),
 
     // 404 Not Found
     NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #134 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 관리자 권한 관리 방식을 수정하였습니다.

- user 테이블에 role 컬럼을 추가하여 guest, host, admin을 관리합니다.
   - role을 enum으로 관리합니다
   - 최초 회원가입 시 role을 guest로 설정합니다.
   - host 승인 시 role을 host로 설정합니다.
   - admin으로 따로 설정 시 관리자 페이지 관련 api를 시큐리티를 통해 허용합니다.
   
- role을 토큰을 통해 확인할 수 있도록 
   `{
  "iat": 34598232,
  "exp": 34598232,
  "memberId": "2",
  "roles": [
    "ROLE_guest"
  ]
}`
로 구조를 변경했습니다.

- admin 권한이 없을 경우 403 NOT_ADMIN 에러가 발생하도록 CustomAccessDeniedHandler를 설정하였습니다.

- 기존 userId로 관리자 권한을 허용해주던 코드를 삭제하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="840" alt="스크린샷 2024-08-12 오후 7 12 19" src="https://github.com/user-attachments/assets/7815faf9-3d42-478e-af79-df022e9d296f">
<img width="842" alt="스크린샷 2024-08-12 오후 7 12 52" src="https://github.com/user-attachments/assets/14715b85-09c4-49c4-8c1f-11e482fb44d2">
<img width="652" alt="스크린샷 2024-08-14 오전 12 36 07" src="https://github.com/user-attachments/assets/2b5565c6-9ed6-424e-bba7-c621eeb7bfd6">
<img width="1470" alt="스크린샷 2024-08-14 오전 12 13 40" src="https://github.com/user-attachments/assets/a994d438-414c-4d0a-83dc-9330adac043e">
<img width="1470" alt="스크린샷 2024-08-14 오전 12 19 46" src="https://github.com/user-attachments/assets/5897012f-1ec3-49a1-b72b-d3a305374d28">

