### PR TITLE
[feat] 누락된 api들 유효성 검증 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -74,7 +74,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
     @PatchMapping("/v1/moim/{moimId}/submitter")
     public ApiResponseDto updateSubmitterState(
             @PathVariable Long moimId,
-            @RequestBody MoimSubmitterUpdateRequest moimSubmitterUpdateRequest
+            @RequestBody @Valid MoimSubmitterUpdateRequest moimSubmitterUpdateRequest
     ) {
         moimSubmissionCommandService.updateSubmissionState(moimId, moimSubmitterUpdateRequest.submitterIdList());
         return ApiResponseDto.success(SuccessCode.MOIM_SUBMITTER_APPROVE_SUCCESS);

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
@@ -1,8 +1,10 @@
 package com.pickple.server.api.moimsubmission.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record MoimSubmitterUpdateRequest(
+        @NotNull
         List<Long> submitterIdList
 ) {
 }

--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -6,6 +6,7 @@ import com.pickple.server.api.notice.service.NoticeCommandService;
 import com.pickple.server.api.notice.service.NoticeQueryService;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,7 +26,7 @@ public class NoticeController implements NoticeControllerDocs {
 
     @PostMapping("/v1/moim/{moimId}/notice")
     public ApiResponseDto createNotice(@PathVariable Long moimId,
-                                       @RequestBody NoticeCreateRequest noticeCreateRequest) {
+                                       @RequestBody @Valid NoticeCreateRequest noticeCreateRequest) {
         noticeCommandService.createNotice(moimId, noticeCreateRequest);
         return ApiResponseDto.success(SuccessCode.NOTICE_POST_SUCCESS);
     }

--- a/src/main/java/com/pickple/server/api/user/controller/UserController.java
+++ b/src/main/java/com/pickple/server/api/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.pickple.server.global.auth.client.dto.UserLoginRequest;
 import com.pickple.server.global.auth.jwt.service.TokenService;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,7 +28,7 @@ public class UserController implements UserControllerDocs {
     @Override
     public ApiResponseDto<LoginSuccessResponse> login(
             @RequestParam final String authorizationCode,
-            @RequestBody final UserLoginRequest loginRequest
+            @RequestBody @Valid final UserLoginRequest loginRequest
     ) {
         return ApiResponseDto.success(SuccessCode.LOGIN_SUCCESS, userService.create(authorizationCode, loginRequest));
     }

--- a/src/main/java/com/pickple/server/global/auth/client/dto/UserLoginRequest.java
+++ b/src/main/java/com/pickple/server/global/auth/client/dto/UserLoginRequest.java
@@ -3,13 +3,14 @@ package com.pickple.server.global.auth.client.dto;
 import com.pickple.server.api.user.domain.SocialType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record UserLoginRequest(
-        @NotBlank(message = "소셜 로그인 종류가 입력되지 않았습니다.")
+        @NotNull(message = "소셜 로그인 종류가 입력되지 않았습니다.")
         @Schema(description = "소셜로그인 타입", example = "KAKAO")
         SocialType socialType,
 
-        @NotBlank
+        @NotBlank(message = "redirectUri가 입력되지 않았습니다.")
         @Schema(description = "리다이텍트 uri 값", example = "https://pick-ple.com/kakao/redirection or http://localhost:5173/kakao/redirection")
         String redirectUri
 ) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #136 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
이것저것 해보다가 픽플에서 로그아웃 후 로그인했는데 에러가 발생하지 않더라구요..? 
지금 웹 배포상태는 redirectUri를 안보내주고 있는데 말이죠!
그래서 유효성 검증이 빠져있는것을 확인하였고 로그인 api에도 유효성 검증을 추가해주었습니다.

추가로 확인하여 총 아래 3개의 api에 추가해주었습니다.
- 로그인 api
- 모임 신청자 승인 api
- 공지사항 작성 api

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
socialTye이 enum형으로 되어있어서 notNull로 처리했습니다

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->

<img width="1470" alt="스크린샷 2024-08-15 오전 3 24 04" src="https://github.com/user-attachments/assets/3358a715-2451-40cf-a5e4-42b20128368a">

<img width="1470" alt="스크린샷 2024-08-15 오전 3 26 05" src="https://github.com/user-attachments/assets/6d6f1715-e660-446a-bc66-21b5df1e1ad5">

`
2024-08-15T03:24:49.711+09:00 ERROR 6357 --- [nio-8080-exec-1] c.p.s.g.e.GlobalExceptionHandler         : handlerMethodArgumentNotValidException() in GlobalExceptionHandler throw MethodArgumentNotValidException : Validation failed for argument [1] in public com.pickple.server.global.response.ApiResponseDto<com.pickple.server.api.user.dto.LoginSuccessResponse> com.pickple.server.api.user.controller.UserController.login(java.lang.String,com.pickple.server.global.auth.client.dto.UserLoginRequest): [Field error in object 'userLoginRequest' on field 'redirectUri': rejected value [null]; codes [NotBlank.userLoginRequest.redirectUri,NotBlank.redirectUri,NotBlank.java.lang.String,NotBlank]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [userLoginRequest.redirectUri,redirectUri]; arguments []; default message [redirectUri]]; default message [redirectUri가 입력되지 않았습니다.]] 

2024-08-15T03:24:49.720+09:00  WARN 6357 --- [nio-8080-exec-1] .m.m.a.ExceptionHandlerExceptionResolver : Resolved [org.springframework.web.bind.MethodArgumentNotValidException: Validation failed for argument [1] in public com.pickple.server.global.response.ApiResponseDto<com.pickple.server.api.user.dto.LoginSuccessResponse> com.pickple.server.api.user.controller.UserController.login(java.lang.String,com.pickple.server.global.auth.client.dto.UserLoginRequest): [Field error in object 'userLoginRequest' on field 'redirectUri': rejected value [null]; codes [NotBlank.userLoginRequest.redirectUri,NotBlank.redirectUri,NotBlank.java.lang.String,NotBlank]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [userLoginRequest.redirectUri,redirectUri]; arguments []; default message [redirectUri]]; default message [redirectUri가 입력되지 않았습니다.]] ]
`
