### PR TITLE
[feat] 모임 진행 상태 스케줄러 추가

### DIFF
--- a/src/main/java/com/pickple/server/PickpleServerApplication.java
+++ b/src/main/java/com/pickple/server/PickpleServerApplication.java
@@ -6,11 +6,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients
 @SpringBootApplication
 @ImportAutoConfiguration(FeignAutoConfiguration.class)
 @EnableJpaAuditing
+@EnableScheduling
 public class PickpleServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/pickple/server/api/moim/domain/Moim.java
+++ b/src/main/java/com/pickple/server/api/moim/domain/Moim.java
@@ -80,4 +80,8 @@ public class Moim extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "moim", cascade = CascadeType.REMOVE)
     private List<MoimSubmission> moimSubmissions = new ArrayList<>();
+
+    public void updateMoimState(String moimState) {
+        this.moimState = moimState;
+    }
 }

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -26,4 +26,10 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
             "WHERE categories.value = :category)",
             nativeQuery = true)
     List<Moim> findMoimListByCategory(@Param("category") String category);
+
+    //@Query(value = "SELECT * FROM moims m WHERE m.date_list->>'date' = :date", nativeQuery = true)
+    //List<Moim> findMoimListByDate(@Param("date") LocalDate date);
+
+    @Query(value = "SELECT * FROM moims WHERE date_list->>'date' = :date", nativeQuery = true)
+    List<Moim> findByDate(String date);
 }

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -27,7 +27,7 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
             nativeQuery = true)
     List<Moim> findMoimListByCategory(@Param("category") String category);
 
-    @Query(value = "SELECT * FROM moims WHERE date_list->>'date' = :date", nativeQuery = true)
+    @Query(value = "SELECT * FROM moims WHERE date_list->>'date' = :date AND moim_state = 'ongoing'", nativeQuery = true)
     List<Moim> findByDate(String date);
 
     @Query("SELECT m FROM Moim m WHERE m.host.id = :hostId AND m.moimState = 'completed'")

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -7,7 +7,10 @@ import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,5 +43,20 @@ public class MoimCommandService {
         return MoimCreateResponse.builder()
                 .moimId(moim.getId())
                 .build();
+    }
+
+    //매일 0시 00분에 실행
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void scheduleDday() {
+        List<Moim> moimList = moimRepository.findAll();
+        LocalDate date = LocalDate.now();
+        System.out.println(date);
+
+        for (Moim moim : moimList) {
+            System.out.println(moim.getDateList().getDate());
+            if (moim.getDateList().getDate().isEqual(date)) {
+                moim.updateMoimState("completed");
+            }
+        }
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -49,12 +49,13 @@ public class MoimCommandService {
 
     //1분마다 실행
     @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
-    public void scheduleDday() {
+    public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
         String formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
         List<Moim> moimList = moimRepository.findByDate(formattedDate);
 
         for (Moim moim : moimList) {
+            System.out.println(moim.getId());
             if (moim.getDateList().getEndTime().isBefore(LocalTime.now())) {
                 moim.updateMoimState("completed");
             }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -55,7 +55,6 @@ public class MoimCommandService {
         List<Moim> moimList = moimRepository.findByDate(formattedDate);
 
         for (Moim moim : moimList) {
-            System.out.println(moim.getId());
             if (moim.getDateList().getEndTime().isBefore(LocalTime.now())) {
                 moim.updateMoimState("completed");
             }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -8,6 +8,8 @@ import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -45,16 +47,15 @@ public class MoimCommandService {
                 .build();
     }
 
-    //매일 0시 00분에 실행
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    //1분마다 실행
+    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
     public void scheduleDday() {
-        List<Moim> moimList = moimRepository.findAll();
         LocalDate date = LocalDate.now();
-        System.out.println(date);
+        String formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        List<Moim> moimList = moimRepository.findByDate(formattedDate);
 
         for (Moim moim : moimList) {
-            System.out.println(moim.getDateList().getDate());
-            if (moim.getDateList().getDate().isEqual(date)) {
+            if (moim.getDateList().getEndTime().isBefore(LocalTime.now())) {
                 moim.updateMoimState("completed");
             }
         }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #138

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 진행 상태 스케줄러 구현
  - 매일 자정에 모임 리스트를 검사하여 해당 날짜와 동일할 경우 ongoing -> completed로 상태를 변경하도록 구현했습니다.
  - 모임 상태를 업데이트 할 수 있도록 모임 엔티티 내에 updateMoimState 함수를 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 지금 로직으로는 스케줄러 함수에서 모든 모임을 불러온 다음 오늘 날짜와 맞는 모임의 경우 상태를 바꿔주는 방식을 사용하도록 구현했는데 이게 모임 갯수가 많아지면 for문을 도는 횟수가 많아져서 비효율적일수도 있겠다는 생각이 들었습니다. 조금 더 나은 방법이 있을까요?

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 스케줄러 작동 이전
<img width="849" alt="스크린샷 2024-08-16 오전 12 53 57" src="https://github.com/user-attachments/assets/799f4ea5-bcee-4ce3-9168-95976a9fb6c8">

- 스케줄러 작동 이후
<img width="642" alt="스크린샷 2024-08-16 오전 12 54 08" src="https://github.com/user-attachments/assets/0e56da97-d9e0-4f68-82b5-66e2a33956da">
