### PR TITLE
[feat] 공지사항 삭제 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -4,11 +4,13 @@ import com.pickple.server.api.notice.dto.request.NoticeCreateRequest;
 import com.pickple.server.api.notice.dto.response.NoticeListGetByMoimResponse;
 import com.pickple.server.api.notice.service.NoticeCommandService;
 import com.pickple.server.api.notice.service.NoticeQueryService;
+import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,5 +37,12 @@ public class NoticeController implements NoticeControllerDocs {
     public ApiResponseDto<List<NoticeListGetByMoimResponse>> getNoticeListByMoimId(@PathVariable Long moimId) {
         return ApiResponseDto.success(SuccessCode.NOTICE_LIST_GET_SUCCESS,
                 noticeQueryService.getNoticeListByMoimId(moimId));
+    }
+
+    @DeleteMapping("/v2/notice/{noticeId}")
+    public ApiResponseDto deleteNotice(@HostId Long hostId,
+                                       @PathVariable Long noticeId) {
+        noticeCommandService.deleteNotice(hostId, noticeId);
+        return ApiResponseDto.success(SuccessCode.NOTICE_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
@@ -1,10 +1,20 @@
 package com.pickple.server.api.notice.repository;
 
 import com.pickple.server.api.notice.domain.Notice;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     List<Notice> findNoticeByMoimIdOrderByCreatedAtDesc(Long moimId);
+
+    Optional<Notice> findNoticeById(Long id);
+
+    default Notice findNoticeByIdOrThrow(Long id) {
+        return findNoticeById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTICE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeCommandService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeCommandService.java
@@ -5,6 +5,8 @@ import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.notice.domain.Notice;
 import com.pickple.server.api.notice.dto.request.NoticeCreateRequest;
 import com.pickple.server.api.notice.repository.NoticeRepository;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +30,13 @@ public class NoticeCommandService {
                 .build();
 
         noticeRepository.save(notice);
+    }
+
+    public void deleteNotice(Long hostId, Long noticeId) {
+        Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
+        if (!hostId.equals(notice.getMoim().getHost().getId())) {
+            throw new CustomException(ErrorCode.NOT_HOST);
+        }
+        noticeRepository.delete(notice);
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     //403 Forbidden
     NOT_ADMIN(40301, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),
+    NOT_HOST(40302, HttpStatus.FORBIDDEN, "해당 모임의 호스트가 아닙니다."),
 
     // 404 Not Found
     NOT_FOUND_END_POINT(40400, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
@@ -37,6 +38,7 @@ public enum ErrorCode {
     HOST_NOT_FOUND(40405, HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다"),
     MOIM_SUBMISSION_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "해당 모임에 신청한 내역이 없습니다."),
     SUBMITTER_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "존재하지 않는 호스트 승인 신청입니다."),
+    NOTICE_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -35,6 +35,7 @@ public enum SuccessCode {
     MOIM_LIST_BY_HOST(20023, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
     SUBMITTER_LIST_GET_SUCCESS(20024, HttpStatus.OK, "호스트 승인 신청 내역 조회 성공"),
     HOST_SUBMITTER_APPROVE_SUCCESS(20025, HttpStatus.OK, "호스트 신청자 승인 성공"),
+    NOTICE_DELETE_SUCCESS(20026, HttpStatus.OK, "공지사항 삭제 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #140

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공지사항 삭제 API 구현
  - 공지사항 삭제 기능을 구현했습니다.
  - 호스트 아이디와 해당 공지사항이 있는 모임의 호스트 아이디를 대조하여 해당 모임의 호스트가 아닌경우 삭제를 할 수 없도록 예외처리를 진행했습니다. 

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 구현하면서 생각난건데 공지사항 작성 API도 hostId 뜯어서 확인하는 과정이 필요하지 않을까 생각합니당

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 공지사항 삭제
<img width="688" alt="스크린샷 2024-08-20 오후 3 26 17" src="https://github.com/user-attachments/assets/699f9c98-f727-4258-aeb3-a5242b4d6bc8">

- 해당 모임의 호스트가 아닌 경우
<img width="692" alt="스크린샷 2024-08-20 오후 3 25 43" src="https://github.com/user-attachments/assets/677dae7b-7889-422f-816a-0ea0d003faf6">
