### PR TITLE
[feat] 공지사항 댓글 작성 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
@@ -1,0 +1,32 @@
+package com.pickple.server.api.comment.controller;
+
+import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
+import com.pickple.server.api.comment.service.CommentCommandService;
+import com.pickple.server.global.common.annotation.HostId;
+import com.pickple.server.global.common.annotation.UserId;
+import com.pickple.server.global.response.ApiResponseDto;
+import com.pickple.server.global.response.enums.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentCommandService commentCommandService;
+
+    @PostMapping("/v2/notice/{noticeId}/comment")
+    public ApiResponseDto createComment(@UserId Long guestId,
+                                        @HostId Long hostId,
+                                        @PathVariable Long noticeId,
+                                        @Valid @RequestBody CommentCreateRequest commentCreateRequest) {
+        commentCommandService.createComment(guestId, hostId, noticeId, commentCreateRequest);
+        return ApiResponseDto.success(SuccessCode.COMMENT_POST_SUCCESS);
+    }
+}

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class CommentController {
+public class CommentController implements CommentControllerDocs {
 
     private final CommentCommandService commentCommandService;
 

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
@@ -2,7 +2,6 @@ package com.pickple.server.api.comment.controller;
 
 import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
 import com.pickple.server.api.comment.service.CommentCommandService;
-import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
@@ -22,11 +21,10 @@ public class CommentController implements CommentControllerDocs {
     private final CommentCommandService commentCommandService;
 
     @PostMapping("/v2/notice/{noticeId}/comment")
-    public ApiResponseDto createComment(@UserId Long guestId,
-                                        @HostId Long hostId,
+    public ApiResponseDto createComment(@UserId Long userId,
                                         @PathVariable Long noticeId,
                                         @Valid @RequestBody CommentCreateRequest commentCreateRequest) {
-        commentCommandService.createComment(guestId, hostId, noticeId, commentCreateRequest);
+        commentCommandService.createComment(userId, noticeId, commentCreateRequest);
         return ApiResponseDto.success(SuccessCode.COMMENT_POST_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
@@ -1,0 +1,37 @@
+package com.pickple.server.api.comment.controller;
+
+import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
+import com.pickple.server.global.common.annotation.HostId;
+import com.pickple.server.global.common.annotation.UserId;
+import com.pickple.server.global.response.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Comment", description = "Comment 관련 API")
+public interface CommentControllerDocs {
+
+    @Operation(summary = "공지사항 댓글 작성")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20027", description = "공지사항 댓글 작성 성공"),
+                    @ApiResponse(responseCode = "40403", description = "존재하지 않는 게스트입니다."),
+                    @ApiResponse(responseCode = "40405", description = "존재하지 않는 호스트입니다."),
+                    @ApiResponse(responseCode = "40409", description = "존재하지 않는 공지사항입니다.")
+            }
+    )
+    ApiResponseDto createComment(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
+            @UserId Long guestId,
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
+            @HostId Long hostId,
+            @PathVariable Long noticeId,
+            @RequestBody CommentCreateRequest commentCreateRequest
+    );
+}

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
@@ -1,7 +1,6 @@
 package com.pickple.server.api.comment.controller;
 
 import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
-import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,9 +27,7 @@ public interface CommentControllerDocs {
     )
     ApiResponseDto createComment(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
-            @UserId Long guestId,
-            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
-            @HostId Long hostId,
+            @UserId Long userId,
             @PathVariable Long noticeId,
             @RequestBody CommentCreateRequest commentCreateRequest
     );

--- a/src/main/java/com/pickple/server/api/comment/domain/Comment.java
+++ b/src/main/java/com/pickple/server/api/comment/domain/Comment.java
@@ -1,0 +1,45 @@
+package com.pickple.server.api.comment.domain;
+
+import com.pickple.server.api.notice.domain.Notice;
+import com.pickple.server.api.user.domain.User;
+import com.pickple.server.global.common.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "comments")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    private String commenterImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User commenter;
+
+    private String commentContent;
+
+    private boolean isOwner;
+}

--- a/src/main/java/com/pickple/server/api/comment/domain/Comment.java
+++ b/src/main/java/com/pickple/server/api/comment/domain/Comment.java
@@ -39,5 +39,4 @@ public class Comment extends BaseTimeEntity {
 
     private String commentContent;
 
-    private boolean isOwner;
 }

--- a/src/main/java/com/pickple/server/api/comment/domain/Comment.java
+++ b/src/main/java/com/pickple/server/api/comment/domain/Comment.java
@@ -33,8 +33,6 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "notice_id")
     private Notice notice;
 
-    private String commenterImageUrl;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User commenter;

--- a/src/main/java/com/pickple/server/api/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,6 @@
+package com.pickple.server.api.comment.dto.request;
+
+public record CommentCreateRequest(
+        String commentContent
+) {
+}

--- a/src/main/java/com/pickple/server/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/pickple/server/api/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.pickple.server.api.comment.repository;
+
+import com.pickple.server.api.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
@@ -1,0 +1,53 @@
+package com.pickple.server.api.comment.service;
+
+import com.pickple.server.api.comment.domain.Comment;
+import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
+import com.pickple.server.api.comment.repository.CommentRepository;
+import com.pickple.server.api.guest.domain.Guest;
+import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.domain.Host;
+import com.pickple.server.api.host.repository.HostRepository;
+import com.pickple.server.api.notice.domain.Notice;
+import com.pickple.server.api.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final NoticeRepository noticeRepository;
+    private final HostRepository hostRepository;
+    private final GuestRepository guestRepository;
+
+    public void createComment(Long guestId,
+                              Long hostId,
+                              Long noticeId,
+                              CommentCreateRequest commentCreateRequest) {
+        Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
+        if (notice.getMoim().getHost().getId().equals(hostId)) {
+            Host host = hostRepository.findHostByIdOrThrow(hostId);
+            Comment comment = Comment.builder()
+                    .notice(notice)
+                    .commenterImageUrl(host.getImageUrl())
+                    .commenter(host.getUser())
+                    .commentContent(commentCreateRequest.commentContent())
+                    .isOwner(true)
+                    .build();
+            commentRepository.save(comment);
+        } else {
+            Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
+            Comment comment = Comment.builder()
+                    .notice(notice)
+                    .commenterImageUrl(guest.getImageUrl())
+                    .commenter(guest.getUser())
+                    .commentContent(commentCreateRequest.commentContent())
+                    .isOwner(false)
+                    .build();
+            commentRepository.save(comment);
+        }
+    }
+}

--- a/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
@@ -3,12 +3,10 @@ package com.pickple.server.api.comment.service;
 import com.pickple.server.api.comment.domain.Comment;
 import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
 import com.pickple.server.api.comment.repository.CommentRepository;
-import com.pickple.server.api.guest.domain.Guest;
-import com.pickple.server.api.guest.repository.GuestRepository;
-import com.pickple.server.api.host.domain.Host;
-import com.pickple.server.api.host.repository.HostRepository;
 import com.pickple.server.api.notice.domain.Notice;
 import com.pickple.server.api.notice.repository.NoticeRepository;
+import com.pickple.server.api.user.domain.User;
+import com.pickple.server.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,32 +18,20 @@ public class CommentCommandService {
 
     private final CommentRepository commentRepository;
     private final NoticeRepository noticeRepository;
-    private final HostRepository hostRepository;
-    private final GuestRepository guestRepository;
+    private final UserRepository userRepository;
 
-    public void createComment(Long guestId,
-                              Long hostId,
+    public void createComment(Long userId,
                               Long noticeId,
                               CommentCreateRequest commentCreateRequest) {
+        User user = userRepository.findUserByIdOrThrow(userId);
         Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
-        if (notice.getMoim().getHost().getId().equals(hostId)) {
-            Host host = hostRepository.findHostByIdOrThrow(hostId);
-            Comment comment = Comment.builder()
-                    .notice(notice)
-                    .commenter(host.getUser())
-                    .commentContent(commentCreateRequest.commentContent())
-                    .isOwner(true)
-                    .build();
-            commentRepository.save(comment);
-        } else {
-            Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
-            Comment comment = Comment.builder()
-                    .notice(notice)
-                    .commenter(guest.getUser())
-                    .commentContent(commentCreateRequest.commentContent())
-                    .isOwner(false)
-                    .build();
-            commentRepository.save(comment);
-        }
+
+        Comment comment = Comment.builder()
+                .notice(notice)
+                .commenter(user)
+                .commentContent(commentCreateRequest.commentContent())
+                .build();
+
+        commentRepository.save(comment);
     }
 }

--- a/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
@@ -32,7 +32,6 @@ public class CommentCommandService {
             Host host = hostRepository.findHostByIdOrThrow(hostId);
             Comment comment = Comment.builder()
                     .notice(notice)
-                    .commenterImageUrl(host.getImageUrl())
                     .commenter(host.getUser())
                     .commentContent(commentCreateRequest.commentContent())
                     .isOwner(true)
@@ -42,7 +41,6 @@ public class CommentCommandService {
             Guest guest = guestRepository.findGuestByIdOrThrow(guestId);
             Comment comment = Comment.builder()
                     .notice(notice)
-                    .commenterImageUrl(guest.getImageUrl())
                     .commenter(guest.getUser())
                     .commentContent(commentCreateRequest.commentContent())
                     .isOwner(false)

--- a/src/main/java/com/pickple/server/api/notice/domain/Notice.java
+++ b/src/main/java/com/pickple/server/api/notice/domain/Notice.java
@@ -1,7 +1,9 @@
 package com.pickple.server.api.notice.domain;
 
+import com.pickple.server.api.comment.domain.Comment;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.global.common.domain.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,8 +11,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,4 +45,7 @@ public class Notice extends BaseTimeEntity {
 
     @Size(max = 500)
     private String imageUrl;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/pickple/server/api/user/domain/User.java
+++ b/src/main/java/com/pickple/server/api/user/domain/User.java
@@ -1,13 +1,18 @@
 package com.pickple.server.api.user.domain;
 
+import com.pickple.server.api.comment.domain.Comment;
 import com.pickple.server.global.common.domain.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,6 +41,9 @@ public class User extends BaseTimeEntity {
     private String socialNickname;
 
     private String role;
+
+    @OneToMany(mappedBy = "commenter", cascade = CascadeType.REMOVE)
+    private List<Comment> commentList = new ArrayList<>();
 
     public void updateRole(String role) {
         this.role = role;

--- a/src/main/java/com/pickple/server/api/user/repository/UserRepository.java
+++ b/src/main/java/com/pickple/server/api/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.pickple.server.api.user.repository;
 
 import com.pickple.server.api.user.domain.SocialType;
 import com.pickple.server.api.user.domain.User;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import feign.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,11 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     @Query("SELECT u FROM User u WHERE u.socialId = :socialId AND u.socialType = :socialType")
     Optional<User> findBySocialTypeAndSocialId(@Param("socialId") Long socialId,
                                                @Param("socialType") SocialType socialType);
+
+    Optional<User> findUserById(Long id);
+
+    default User findUserByIdOrThrow(Long id) {
+        return findUserById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -36,7 +36,7 @@ public enum SuccessCode {
     SUBMITTER_LIST_GET_SUCCESS(20024, HttpStatus.OK, "호스트 승인 신청 내역 조회 성공"),
     HOST_SUBMITTER_APPROVE_SUCCESS(20025, HttpStatus.OK, "호스트 신청자 승인 성공"),
     NOTICE_DELETE_SUCCESS(20026, HttpStatus.OK, "공지사항 삭제 성공"),
-
+    COMMENT_POST_SUCCESS(20027, HttpStatus.OK, "공지사항 댓글 작성 성공"),
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #146 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공지사항 댓글 작성 API 구현
  - 댓글 엔티티를 구현했습니다.
  - 서비스 로직에서 해당 사용자의 hostId가 공지사항의 모임 스픽커 id와 같은 경우 isOwner를 true로, 게스트인 경우 false로 지정해주었습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 지난 PR에서 말씀해주셨던 공지사항 삭제 시 댓글도 함께 전체 삭제되는 것을 확인했습니다.
- 댓글 작성자(commenter)를 지정하는 과정에서 생각을 많이 했는데, 현재는 일단 hostId랑 guestId 뜯어와서 분기처리 한 다음 해당 role에 맞는 이미지랑 닉네임 뜯어오고 있고, 매핑은 각 id값에 맞는 유저랑 매핑시켜놨습니다. 근데 이렇게 처리하는게 최선인지는 잘 모르겠습니다.... 대부분은 그냥 member로만 매핑시키는게 많아서 참고하기 어렵더라고요..... 좀 더 나은 방향이 있는지 궁금합니다

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1016" alt="스크린샷 2024-08-27 오후 5 13 15" src="https://github.com/user-attachments/assets/50952817-ce29-4300-bbb3-283c0b7a57a8">
<img width="1048" alt="스크린샷 2024-08-27 오후 5 40 45" src="https://github.com/user-attachments/assets/138ac2cb-78ee-47b1-b658-dedd695b4bb8">
