### PR TITLE
[feat] 호스트 정보 조회 api 2차 스프린트 로직 반영 

### DIFF
--- a/src/main/java/com/pickple/server/api/host/controller/HostController.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostController.java
@@ -19,7 +19,7 @@ public class HostController implements HostControllerDocs {
 
     private final HostQueryService hostQueryService;
 
-    @GetMapping("/v1/host")
+    @GetMapping("/v2/host")
     public ApiResponseDto<HostGetResponse> getHost(@HostId Long hostId) {
         return ApiResponseDto.success(SuccessCode.HOST_DETAIL_GET_SUCCESS, hostQueryService.getHost(hostId));
     }

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostGetResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostGetResponse.java
@@ -18,4 +18,10 @@ public class HostGetResponse {
     private String hostLink; // 호스트가 추가한 링크
 
     private Long hostId;
+
+    private String keyword; //키워드
+
+    private int moimCount; // 모임 수
+
+    private int attendeeCount; // 참여자 수
 }

--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -56,4 +56,8 @@ public class HostQueryService {
 
         return moimSubmissionRepository.countApprovedSubmissionsByMoimIds(moimIds);
     }
+
+    private int moimCounter(Long hostId) {
+        return moimRepository.CompletedMoimNumber(hostId);
+    }
 }

--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -6,7 +6,9 @@ import com.pickple.server.api.host.dto.response.HostGetResponse;
 import com.pickple.server.api.host.repository.HostRepository;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,7 @@ public class HostQueryService {
 
     private final HostRepository hostRepository;
     private final MoimRepository moimRepository;
+    private final MoimSubmissionRepository moimSubmissionRepository;
 
     public HostGetResponse getHost(Long hostId) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
@@ -26,6 +29,9 @@ public class HostQueryService {
                 .hostImageUrl(host.getImageUrl())
                 .hostNickName(host.getNickname())
                 .hostLink(host.getLink())
+                .keyword(host.getUserKeyword())
+                .attendeeCount(attendeeCounter(hostId))
+                .moimCount(moimCounter(hostId))
                 .build();
     }
 
@@ -39,5 +45,15 @@ public class HostQueryService {
                 .hostImageUrl(host.getImageUrl())
                 .count(count)
                 .build();
+    }
+
+    private int attendeeCounter(Long hostId) {
+        List<Moim> moimList = moimRepository.findCompletedMoimsByHostId(hostId);
+
+        List<Long> moimIds = moimList.stream()
+                .map(Moim::getId) // Moim 엔티티에서 id를 추출
+                .collect(Collectors.toList());
+
+        return moimSubmissionRepository.countApprovedSubmissionsByMoimIds(moimIds);
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -26,4 +26,10 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
             "WHERE categories.value = :category)",
             nativeQuery = true)
     List<Moim> findMoimListByCategory(@Param("category") String category);
+
+    @Query("SELECT m FROM Moim m WHERE m.host.id = :hostId AND m.moimState = 'completed'")
+    List<Moim> findCompletedMoimsByHostId(@Param("hostId") Long hostId);
+
+    @Query("SELECT COUNT(m) FROM Moim m WHERE m.host.id = :hostId AND m.moimState = 'completed'")
+    int CompletedMoimNumber(Long hostId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -28,4 +28,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     @Query(value = "SELECT COUNT(*) FROM moim_submissions WHERE moim_id = :moimId AND moim_submission_state = 'approved'", nativeQuery = true)
     long countApprovedMoimSubmissions(@Param("moimId") Long moimId);
+
+    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'approved'")
+    int countApprovedSubmissionsByMoimIds(@Param("moimIds") List<Long> moimIds);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #152 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
호스트 정보 조회 api에 2차 스프린트 로직을 반영했습니다.
-  키워드, 클래스 횟수, 참여자 수 추가 했습니다.
- 완료된 모임 횟수 카운팅을 위해 hostId가 일치하고 moimState가 completed 인 모임의 횟수를 카운팅했습니다.
- 완료된 모임의 참가자 수 카운팅을 위해 hostId가 일치하는 모임의 id를 갖고와 모임 신청테이블에서 모임 id가 일치하고 신청상태가 approved인 신청의 횟수를 카운팅했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1204" alt="스크린샷 2024-08-27 오후 10 36 10" src="https://github.com/user-attachments/assets/09725d93-5405-4dc6-b1ad-29c21da75598">

<img width="975" alt="스크린샷 2024-08-27 오후 10 35 31" src="https://github.com/user-attachments/assets/ba296de2-9994-4149-ab59-725866df58e2">

<img width="1470" alt="스크린샷 2024-08-27 오후 10 32 06" src="https://github.com/user-attachments/assets/84c42dd2-f3d2-46b4-9696-90b186e39408">
