### PR TITLE
[feat] 모임에 해당하는 호스트 정보 조회 API 2차스프린트 반영

### DIFF
--- a/src/main/java/com/pickple/server/api/host/controller/HostController.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostController.java
@@ -24,7 +24,7 @@ public class HostController implements HostControllerDocs {
         return ApiResponseDto.success(SuccessCode.HOST_DETAIL_GET_SUCCESS, hostQueryService.getHost(hostId));
     }
 
-    @GetMapping("/v1/host/{hostId}")
+    @GetMapping("/v2/host/{hostId}")
     public ApiResponseDto<HostByMoimResponse> getMoimHost(@PathVariable Long hostId) {
         return ApiResponseDto.success(SuccessCode.HOST_BY_MOIM_GET_SUCCESS, hostQueryService.getHostByMoim(hostId));
     }

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 public record HostByMoimResponse(
         String hostNickName,    // 호스트 닉네임
         String hostImageUrl,    // 호스트 프로필 사진 url
-        String count,           // 호스트의 모임 횟수(두자릿수)
+        int count,           // 호스트의 모임 횟수(두자릿수)
         String userKeyword,
         String description
 ) {

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 public record HostByMoimResponse(
         String hostNickName,    // 호스트 닉네임
         String hostImageUrl,    // 호스트 프로필 사진 url
-        String count           // 호스트의 모임 횟수(두자릿수)
+        String count,           // 호스트의 모임 횟수(두자릿수)
+        String userKeyword,
+        String description
 ) {
 }

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
@@ -7,7 +7,7 @@ public record HostByMoimResponse(
         String hostNickName,    // 호스트 닉네임
         String hostImageUrl,    // 호스트 프로필 사진 url
         int count,           // 호스트의 모임 횟수(두자릿수)
-        String userKeyword,
+        String keyword,
         String description
 ) {
 }

--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -44,6 +44,8 @@ public class HostQueryService {
                 .hostNickName(host.getNickname())
                 .hostImageUrl(host.getImageUrl())
                 .count(count)
+                .userKeyword(host.getUserKeyword())
+                .description(host.getDescription())
                 .build();
     }
 

--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -42,7 +42,7 @@ public class HostQueryService {
                 .hostNickName(host.getNickname())
                 .hostImageUrl(host.getImageUrl())
                 .count(moimRepository.countByHostId(hostId))
-                .userKeyword(host.getUserKeyword())
+                .keyword(host.getUserKeyword())
                 .description(host.getDescription())
                 .build();
     }

--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -37,13 +37,11 @@ public class HostQueryService {
 
     public HostByMoimResponse getHostByMoim(Long hostId) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
-        List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
-        String count = String.format("%02d", moimList.size());
 
         return HostByMoimResponse.builder()
                 .hostNickName(host.getNickname())
                 .hostImageUrl(host.getImageUrl())
-                .count(count)
+                .count(moimRepository.countByHostId(hostId))
                 .userKeyword(host.getUserKeyword())
                 .description(host.getDescription())
                 .build();

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 public interface MoimRepository extends JpaRepository<Moim, Long> {
     Optional<Moim> findMoimById(Long id);
 
-    List<Moim> findMoimByHostId(Long hostId);
+    int countByHostId(Long hostId);
 
     List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #154

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
모임에 해당하는 호스트 정보 조회 API에 2차스프린트 반영했습니다.
- resoponse에 키워드와 설명을 추가했습니다.
- 모임 횟수 노출이 아닌 2회 이상일경우 스티커를 붙이는 기획으로 변경됨에 따라 기존에 모임 수를 2자리 수로 string형으로 response에 담았던 로직을 삭제하고 바로 카운팅하여 Int형으로 반환하도록 수정하였습니다

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![스크린샷 2024-08-28 오후 11 49 06](https://github.com/user-attachments/assets/068272cf-d0f6-4834-9b6d-b1139679fc5a)

