### PR TITLE
[refactor] presiginedUrl 요청 방식 리팩토링

### DIFF
--- a/src/main/java/com/pickple/server/global/common/external/s3/S3Controller.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/S3Controller.java
@@ -1,11 +1,13 @@
 package com.pickple.server.global.common.external.s3;
 
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlClientRequest;
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlResponse;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,22 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class S3Controller implements S3ControllerDocs {
     private final S3Service s3Service;
 
-    @GetMapping("/v1/moim-image-list/upload/{count}")
+    @GetMapping("/v2/image/upload")
     @Override
-    public ApiResponseDto<List<PreSignedUrlResponse>> getMoimPreSignedUrl(
-            @PathVariable int count
+    public ApiResponseDto<List<PreSignedUrlResponse>> getPreSignedUrl(
+            @RequestBody PreSignedUrlClientRequest request
     ) {
         return ApiResponseDto.success(SuccessCode.PRESIGNED_URL_GET_SUCCESS,
-                s3Service.getUploadPreSignedUrlList(S3BucketDirectory.MOIM_PREFIX, count));
-    }
-
-    @GetMapping("/v1/notice-image-list/upload/{count}")
-    @Override
-    public ApiResponseDto<List<PreSignedUrlResponse>> getNoticePreSignedUrl(
-            @PathVariable int count
-    ) {
-        return ApiResponseDto.success(SuccessCode.PRESIGNED_URL_GET_SUCCESS,
-                s3Service.getUploadPreSignedUrlList(S3BucketDirectory.NOTICE_PREFIX, count));
+                s3Service.getUploadPreSignedUrlList(request));
     }
 }
 

--- a/src/main/java/com/pickple/server/global/common/external/s3/S3ControllerDocs.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/S3ControllerDocs.java
@@ -1,33 +1,26 @@
 package com.pickple.server.global.common.external.s3;
 
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlClientRequest;
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlResponse;
 import com.pickple.server.global.response.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Image - PreSigned Url", description = "이미지 업로드 할 Url 받기")
 public interface S3ControllerDocs {
 
-    @Operation(summary = "모임 이미지 업로드 presigned url")
+    @Operation(summary = "이미지 업로드 presigned url")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "20008", description = "모임 presigned url 발급 성공"),
+                    @ApiResponse(responseCode = "20009", description = "presigned url 발급 성공"),
                     @ApiResponse(responseCode = "50001", description = "S3 presigned url을 받아오기에 실패했습니다.")
             }
     )
-    ApiResponseDto<List<PreSignedUrlResponse>> getMoimPreSignedUrl(@PathVariable int count);
-
-    @Operation(summary = "공지 이미지 업로드 presigned url")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(responseCode = "20008", description = "공지 presigned url 발급 성공"),
-                    @ApiResponse(responseCode = "50001", description = "S3 presigned url을 받아오기에 실패했습니다.")
-            }
-    )
-    ApiResponseDto<List<PreSignedUrlResponse>> getNoticePreSignedUrl(@PathVariable int count);
+    ApiResponseDto<List<PreSignedUrlResponse>> getPreSignedUrl(@RequestBody PreSignedUrlClientRequest clientRequest);
 }
 
 

--- a/src/main/java/com/pickple/server/global/common/external/s3/S3Service.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/S3Service.java
@@ -1,6 +1,8 @@
 package com.pickple.server.global.common.external.s3;
 
 
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlClientRequest;
+import com.pickple.server.global.common.external.s3.dto.PreSignedUrlResponse;
 import com.pickple.server.global.config.AwsConfig;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
@@ -37,12 +39,12 @@ public class S3Service {
     }
 
     // PreSigned Url을 통한 이미지 업로드
-    public List<PreSignedUrlResponse> getUploadPreSignedUrlList(final S3BucketDirectory prefix, int count) {
+    public List<PreSignedUrlResponse> getUploadPreSignedUrlList(PreSignedUrlClientRequest clientRequest) {
         List<PreSignedUrlResponse> preSignedUrlList = new ArrayList<>();
 
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < clientRequest.count(); i++) {
             final String fileName = generateImageFileName();   // UUID 문자열
-            final String key = prefix.value() + fileName;
+            final String key = clientRequest.prefix().value() + fileName;
 
             try {
                 final S3Presigner preSigner = awsConfig.getS3PreSigner();

--- a/src/main/java/com/pickple/server/global/common/external/s3/controller/S3Controller.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/controller/S3Controller.java
@@ -1,5 +1,6 @@
-package com.pickple.server.global.common.external.s3;
+package com.pickple.server.global.common.external.s3.controller;
 
+import com.pickple.server.global.common.external.s3.S3Service;
 import com.pickple.server.global.common.external.s3.dto.PreSignedUrlClientRequest;
 import com.pickple.server.global.common.external.s3.dto.PreSignedUrlResponse;
 import com.pickple.server.global.response.ApiResponseDto;

--- a/src/main/java/com/pickple/server/global/common/external/s3/controller/S3ControllerDocs.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/controller/S3ControllerDocs.java
@@ -1,4 +1,4 @@
-package com.pickple.server.global.common.external.s3;
+package com.pickple.server.global.common.external.s3.controller;
 
 import com.pickple.server.global.common.external.s3.dto.PreSignedUrlClientRequest;
 import com.pickple.server.global.common.external.s3.dto.PreSignedUrlResponse;

--- a/src/main/java/com/pickple/server/global/common/external/s3/dto/PreSignedUrlClientRequest.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/dto/PreSignedUrlClientRequest.java
@@ -1,0 +1,9 @@
+package com.pickple.server.global.common.external.s3.dto;
+
+import com.pickple.server.global.common.external.s3.S3BucketDirectory;
+
+public record PreSignedUrlClientRequest(
+        S3BucketDirectory prefix,
+        int count
+) {
+}

--- a/src/main/java/com/pickple/server/global/common/external/s3/dto/PreSignedUrlResponse.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/dto/PreSignedUrlResponse.java
@@ -1,4 +1,4 @@
-package com.pickple.server.global.common.external.s3;
+package com.pickple.server.global.common.external.s3.dto;
 
 public record PreSignedUrlResponse(
         String fileName,


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #157 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
presiginedUrl 요청 방식을 리팩토링 했습니다.
- 기존에는 모임, 공지사항 등등 이미지가 s3에 저장되는 폴더를 구분하기 위해 엔드포인트를 다르게 하여 서버에서 api 마다 s3의 폴더를 지정해주었는데 requestBody로 이미지의 구분 종류(ex-모임 이미지, 공지사항 이미지)와 필요한 개수를 전달 받도록 하여 이미지가 필요한 곳(리뷰 프로필 변경 등)이 확장되어도 중복 코드가 발생하지 않도록 하였습니다.
- 기존에도 폴더가 [eum](https://github.com/PICK-PLE/PICKPLE-server/blob/15462f4f9271fc6d19bb319e106d5a613e12aab7/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java)으로 관리되고 있었기 때문에 해당 eum을 requestBody의 prefix의 타입으로 지정하여 정하지 않은 타입이 들어왔을때 오류를 방지했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 해당 pr내용과 prefix는 머지 후 슬랙으로 클라쌤들한테 전달할 예정입니다.
- 앞으로 스프린트를 진행하며 이미지가 필요한 곳 (ex- 리뷰 작성, 프로필 수정)을 구현하실 때 [eum](https://github.com/PICK-PLE/PICKPLE-server/blob/15462f4f9271fc6d19bb319e106d5a613e12aab7/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java)에 꼭! 추가해주세요!!! 안하시면 클라쌤들 어리둥절입니다!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![스크린샷 2024-08-29 오전 2 04 21](https://github.com/user-attachments/assets/1efd4d59-96e7-4e07-9336-459445901857)
![스크린샷 2024-08-29 오전 2 11 06](https://github.com/user-attachments/assets/8472f933-1008-4452-9fd1-61f2c8f31789)
