### PR TITLE
[feat] 모임 신청 내역 승인대기로 변경 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -79,4 +79,10 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
         moimSubmissionCommandService.updateSubmissionState(moimId, moimSubmitterUpdateRequest.submitterIdList());
         return ApiResponseDto.success(SuccessCode.MOIM_SUBMITTER_APPROVE_SUCCESS);
     }
+
+    @PatchMapping("v2/moimSubmission/{moimSubmissionId}")
+    public ApiResponseDto updateMoimSubmissionStateToPendingApproval(@PathVariable Long moimSubmissionId) {
+        moimSubmissionCommandService.updateMoimSubmissionStateToPendingApproval(moimSubmissionId);
+        return ApiResponseDto.success(SuccessCode.MOIM_SUBMISSION_STATE_UPDATE_SUCCESS);
+    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -2,12 +2,18 @@ package com.pickple.server.api.moimsubmission.repository;
 
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, Long> {
+
+    Optional<MoimSubmission> findMoimSubmissionById(Long id);
+
     boolean existsByMoimAndGuestId(Moim moim, Long guestId);
 
     List<MoimSubmission> findAllByGuestId(Long guestId);
@@ -31,4 +37,9 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'approved'")
     int countApprovedSubmissionsByMoimIds(@Param("moimIds") List<Long> moimIds);
+
+    default MoimSubmission findMoimSubmissionByIdOrThrow(Long id) {
+        return findMoimSubmissionById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -61,4 +61,13 @@ public class MoimSubmissionCommandService {
             moimSubmissionRepository.save(moimSubmission);
         }
     }
+
+    public void updateMoimSubmissionStateToPendingApproval(Long moimSubmissionId) {
+        MoimSubmission moimSubmission = moimSubmissionRepository.findMoimSubmissionByIdOrThrow(moimSubmissionId);
+
+        if (moimSubmission.getMoimSubmissionState()
+                .equals(MoimSubmissionState.PENDING_PAYMENT.getMoimSubmissionState())) {
+            moimSubmission.updateMoimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState());
+        }
+    }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -68,6 +68,8 @@ public class MoimSubmissionCommandService {
         if (moimSubmission.getMoimSubmissionState()
                 .equals(MoimSubmissionState.PENDING_PAYMENT.getMoimSubmissionState())) {
             moimSubmission.updateMoimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState());
+        } else {
+            throw new CustomException(ErrorCode.MOIM_SUBMISSION_STATE_TRANSITION_NOT_ALLOWED);
         }
     }
 }

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -43,6 +43,9 @@ public enum ErrorCode {
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),
 
+    // 422 Unprocessable Entity
+    MOIM_SUBMISSION_STATE_TRANSITION_NOT_ALLOWED(42200, HttpStatus.UNPROCESSABLE_ENTITY, "모임 신청 상태가 입금 대기 상태가 이닙니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     PRESIGNED_URL_GET_ERROR(50001, HttpStatus.INTERNAL_SERVER_ERROR, "S3 presigned url을 받아오기에 실패했습니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -37,6 +37,7 @@ public enum SuccessCode {
     HOST_SUBMITTER_APPROVE_SUCCESS(20025, HttpStatus.OK, "호스트 신청자 승인 성공"),
     NOTICE_DELETE_SUCCESS(20026, HttpStatus.OK, "공지사항 삭제 성공"),
     REVIEW_TAG_LIST_GET_SUCCESS(20027, HttpStatus.OK, "리뷰 태그 전체 조회 성공"),
+    MOIM_SUBMISSION_STATE_UPDATE_SUCCESS(20031, HttpStatus.OK, "모임 신청 내역 승인대기로 변경 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #163 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 신청 내역 승인대기로 변경 API를 구현했습니다.
   - 모임 신청 내역에서 입금이 확인된 다음 승인 대기 상태로 넘어가야하기 때문에 상태가 승인대기인 경우에만 요청이 이뤄지고 아닐경우엔 에러처리를 진행했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 성공 코드를 204로 하고싶었는데(반환되는 data가 없다고 생각해서) 응답시 아무것도 안나오는 상황이 나와서 찾아보니 204의 경우  response body를 보여주지 않고 넘어간다고 하네용. 아티클 작성해보겠습니다 [참고 레퍼런스](https://velog.io/@server30sopt/204-NOCONTENT%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%84%EC%8B%9C%EB%82%98%EC%9A%94)

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-08-29 오후 5 33 54" src="https://github.com/user-attachments/assets/7e4b5a96-91e2-4e11-b9fb-d60856f0179e">
<img width="1470" alt="스크린샷 2024-08-29 오후 5 43 13" src="https://github.com/user-attachments/assets/b36a83cb-c383-4ced-886e-7e1adc579bcc">
<img width="359" alt="스크린샷 2024-08-29 오후 5 43 45" src="https://github.com/user-attachments/assets/47f9f050-deeb-4d73-abd0-b419743a3576">
