### PR TITLE
[feat] 공지사항에 해당하는 댓글 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
@@ -1,12 +1,16 @@
 package com.pickple.server.api.comment.controller;
 
 import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
+import com.pickple.server.api.comment.dto.response.CommentGetResponse;
 import com.pickple.server.api.comment.service.CommentCommandService;
+import com.pickple.server.api.comment.service.CommentQueryService;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController implements CommentControllerDocs {
 
     private final CommentCommandService commentCommandService;
+    private final CommentQueryService commentQueryService;
 
     @PostMapping("/v2/notice/{noticeId}/comment")
     public ApiResponseDto createComment(@UserId Long userId,
@@ -26,5 +31,11 @@ public class CommentController implements CommentControllerDocs {
                                         @Valid @RequestBody CommentCreateRequest commentCreateRequest) {
         commentCommandService.createComment(userId, noticeId, commentCreateRequest);
         return ApiResponseDto.success(SuccessCode.COMMENT_POST_SUCCESS);
+    }
+
+    @GetMapping("/v2/notice/{noticeId}/comment-list")
+    public ApiResponseDto<List<CommentGetResponse>> getCommentByNotice(@PathVariable Long noticeId) {
+        return ApiResponseDto.success(SuccessCode.COMMENT_LIST_BY_NOTICE_GET_SUCCESS,
+                commentQueryService.getCommentListByNotice(noticeId));
     }
 }

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentController.java
@@ -34,7 +34,7 @@ public class CommentController implements CommentControllerDocs {
     }
 
     @GetMapping("/v2/notice/{noticeId}/comment-list")
-    public ApiResponseDto<List<CommentGetResponse>> getCommentByNotice(@PathVariable Long noticeId) {
+    public ApiResponseDto<List<CommentGetResponse>> getCommentListByNotice(@PathVariable Long noticeId) {
         return ApiResponseDto.success(SuccessCode.COMMENT_LIST_BY_NOTICE_GET_SUCCESS,
                 commentQueryService.getCommentListByNotice(noticeId));
     }

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.comment.controller;
 
 import com.pickple.server.api.comment.dto.request.CommentCreateRequest;
+import com.pickple.server.api.comment.dto.response.CommentGetResponse;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -30,5 +32,16 @@ public interface CommentControllerDocs {
             @UserId Long userId,
             @PathVariable Long noticeId,
             @RequestBody CommentCreateRequest commentCreateRequest
+    );
+
+    @Operation(summary = "공지사항 댓글 전체 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20032", description = "공지사항 댓글 작성 성공"),
+                    @ApiResponse(responseCode = "40409", description = "존재하지 않는 공지사항입니다.")
+            }
+    )
+    ApiResponseDto<List<CommentGetResponse>> getCommentListByNotice(
+            @PathVariable Long noticeId
     );
 }

--- a/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/comment/controller/CommentControllerDocs.java
@@ -34,7 +34,7 @@ public interface CommentControllerDocs {
             @RequestBody CommentCreateRequest commentCreateRequest
     );
 
-    @Operation(summary = "공지사항 댓글 전체 조회")
+    @Operation(summary = "공지사항에 해당하는 댓글 전체 조회")
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "20032", description = "공지사항 댓글 작성 성공"),

--- a/src/main/java/com/pickple/server/api/comment/domain/CommenterInfo.java
+++ b/src/main/java/com/pickple/server/api/comment/domain/CommenterInfo.java
@@ -1,0 +1,12 @@
+package com.pickple.server.api.comment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommenterInfo {
+    private String profileImageUrl;
+
+    private String profileNickname;
+}

--- a/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
@@ -1,0 +1,13 @@
+package com.pickple.server.api.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentGetResponse(
+        boolean isOwner,
+        String commenterImageUrl,
+        String commenterNickname,
+        String commentContent,
+        String commentDate
+) {
+}

--- a/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
@@ -5,9 +5,13 @@ import lombok.Builder;
 @Builder
 public record CommentGetResponse(
         boolean isOwner,
+
         String commenterImageUrl,
+
         String commenterNickname,
+
         String commentContent,
+
         String commentDate
 ) {
 }

--- a/src/main/java/com/pickple/server/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/pickple/server/api/comment/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package com.pickple.server.api.comment.repository;
 
 import com.pickple.server.api.comment.domain.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findCommentsByNoticeId(Long noticeId);
 }

--- a/src/main/java/com/pickple/server/api/comment/service/CommentQueryService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentQueryService.java
@@ -1,0 +1,62 @@
+package com.pickple.server.api.comment.service;
+
+import com.pickple.server.api.comment.domain.Comment;
+import com.pickple.server.api.comment.dto.response.CommentGetResponse;
+import com.pickple.server.api.comment.repository.CommentRepository;
+import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.repository.HostRepository;
+import com.pickple.server.api.notice.domain.Notice;
+import com.pickple.server.api.notice.repository.NoticeRepository;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService {
+    private final NoticeRepository noticeRepository;
+    private final CommentRepository commentRepository;
+    private final HostRepository hostRepository;
+    private final GuestRepository guestRepository;
+
+    public List<CommentGetResponse> getCommentListByNotice(Long noticeId) {
+        Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
+        List<Comment> commentList = commentRepository.findCommentsByNoticeId(noticeId);
+
+        return commentList.stream().map(comment -> CommentGetResponse.builder()
+                        .isOwner(checkOwner(comment.getCommenter().getId(), noticeId))
+                        .commenterImageUrl(getCommenterImageUrl(comment.getCommenter().getId(),
+                                checkOwner(comment.getCommenter().getId(), noticeId)))
+                        .commenterNickname(getCommenterNickname(comment.getCommenter().getId(),
+                                checkOwner(comment.getCommenter().getId(), noticeId)))
+                        .commentContent(comment.getCommentContent())
+                        .commentDate(comment.getCommentContent().formatted(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public String getCommenterNickname(Long userId, boolean isOwner) {
+        if (isOwner) {
+            return hostRepository.findHostByUserId(userId).getNickname();
+        } else {
+            return guestRepository.findGuestByUserId(userId).getNickname();
+        }
+    }
+
+    public String getCommenterImageUrl(Long userId, boolean isOwner) {
+        if (isOwner) {
+            return hostRepository.findHostByUserId(userId).getImageUrl();
+        } else {
+            return guestRepository.findGuestByUserId(userId).getImageUrl();
+        }
+    }
+
+    public boolean checkOwner(Long userId, Long noticeId) {
+        Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
+        return notice.getMoim().getHost().getUser().getId().equals(userId);
+    }
+}

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -40,7 +40,8 @@ public enum SuccessCode {
     REVIEW_TAG_LIST_GET_SUCCESS(20028, HttpStatus.OK, "리뷰 태그 전체 조회 성공"),
     HOSTINTRO_GET_SUCCESS(20029, HttpStatus.OK, "호스트 소개 조회 성공"),
     MOIM_SUBMISSION_STATE_UPDATE_SUCCESS(20030, HttpStatus.OK, "모임 신청 내역 승인대기로 변경 성공"),
- 
+    COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20031, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
+
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");
 

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -40,7 +40,7 @@ public enum SuccessCode {
     REVIEW_TAG_LIST_GET_SUCCESS(20028, HttpStatus.OK, "리뷰 태그 전체 조회 성공"),
     HOSTINTRO_GET_SUCCESS(20029, HttpStatus.OK, "호스트 소개 조회 성공"),
     MOIM_SUBMISSION_STATE_UPDATE_SUCCESS(20030, HttpStatus.OK, "모임 신청 내역 승인대기로 변경 성공"),
-    COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20031, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
+    COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20032, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공");


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #166 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공지사항에 해당하는 댓글 전체 조회 API 구현
  - 해당 모임의 호스트 여부를 바탕으로 (isOwner) 프로필 이미지와 닉네임을 각각 가져오는 함수를 구현했습니다.
  https://github.com/PICK-PLE/PICKPLE-server/blob/718ecba9072c0e4cd72bdce3a61baf64d615186b/src/main/java/com/pickple/server/api/comment/service/CommentQueryService.java#L42-L57

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 명세서에 작성자명을 commenter라고 쓰면 헷갈릴 것 같아 commenterNickname으로 수정했습니다. (필드명도 같이 수정)

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1373" alt="스크린샷 2024-08-30 오전 3 00 46" src="https://github.com/user-attachments/assets/5e3cfeb9-d923-424b-8f5e-157b5bd12ca9">
