### PR TITLE
[feat] 호스트 프로필 수정 API 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/host/controller/HostController.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostController.java
@@ -9,6 +9,7 @@ import com.pickple.server.api.host.service.HostQueryService;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -43,7 +44,7 @@ public class HostController implements HostControllerDocs {
 
     @PatchMapping("v2/host/{hostId}")
     public ApiResponseDto<HostUpdateRequest> updateHostProfile(@PathVariable final Long hostId,
-                                                               @RequestBody HostUpdateRequest hostUpdateRequest) {
+                                                               @RequestBody @Valid HostUpdateRequest hostUpdateRequest) {
         hostCommandService.updateHostProfile(hostId, hostUpdateRequest);
         return ApiResponseDto.success(SuccessCode.HOST_PROFILE_UPDATE_SUCCESS);
     }

--- a/src/main/java/com/pickple/server/api/host/controller/HostController.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostController.java
@@ -1,15 +1,19 @@
 package com.pickple.server.api.host.controller;
 
+import com.pickple.server.api.host.dto.request.HostUpdateRequest;
 import com.pickple.server.api.host.dto.response.HostByMoimResponse;
 import com.pickple.server.api.host.dto.response.HostGetResponse;
 import com.pickple.server.api.host.dto.response.HostIntroGetResponse;
+import com.pickple.server.api.host.service.HostCommandService;
 import com.pickple.server.api.host.service.HostQueryService;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HostController implements HostControllerDocs {
 
     private final HostQueryService hostQueryService;
+    private final HostCommandService hostCommandService;
 
     @GetMapping("/v2/host")
     public ApiResponseDto<HostGetResponse> getHost(@HostId Long hostId) {
@@ -34,5 +39,12 @@ public class HostController implements HostControllerDocs {
     @GetMapping("/v2/host/{hostId}/intro")
     public ApiResponseDto<HostIntroGetResponse> getHostIntro(@PathVariable Long hostId) {
         return ApiResponseDto.success(SuccessCode.HOSTINTRO_GET_SUCCESS, hostQueryService.getHostIntro(hostId));
+    }
+
+    @PatchMapping("v2/host/{hostId}")
+    public ApiResponseDto<HostUpdateRequest> updateHostProfile(@PathVariable final Long hostId,
+                                                               @RequestBody HostUpdateRequest hostUpdateRequest) {
+        hostCommandService.updateHostProfile(hostId, hostUpdateRequest);
+        return ApiResponseDto.success(SuccessCode.HOST_PROFILE_UPDATE_SUCCESS);
     }
 }

--- a/src/main/java/com/pickple/server/api/host/controller/HostControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostControllerDocs.java
@@ -1,5 +1,6 @@
 package com.pickple.server.api.host.controller;
 
+import com.pickple.server.api.host.dto.request.HostUpdateRequest;
 import com.pickple.server.api.host.dto.response.HostByMoimResponse;
 import com.pickple.server.api.host.dto.response.HostGetResponse;
 import com.pickple.server.api.host.dto.response.HostIntroGetResponse;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Host", description = "Host 관련 API")
 public interface HostControllerDocs {
@@ -50,5 +52,17 @@ public interface HostControllerDocs {
     )
     ApiResponseDto<HostIntroGetResponse> getHostIntro(
             @PathVariable Long hostId
+    );
+
+    @Operation(summary = "호스트 프로필 수정")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20029", description = "호스트 프로필 수정 성공"),
+                    @ApiResponse(responseCode = "40405", description = "존재하지 않는 호스트입니다.")
+            }
+    )
+    ApiResponseDto<HostUpdateRequest> updateHostProfile(
+            @PathVariable final Long hostId,
+            @RequestBody HostUpdateRequest hostUpdateRequest
     );
 }

--- a/src/main/java/com/pickple/server/api/host/controller/HostControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/host/controller/HostControllerDocs.java
@@ -57,7 +57,7 @@ public interface HostControllerDocs {
     @Operation(summary = "호스트 프로필 수정")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "20029", description = "호스트 프로필 수정 성공"),
+                    @ApiResponse(responseCode = "20035", description = "호스트 프로필 수정 성공"),
                     @ApiResponse(responseCode = "40405", description = "존재하지 않는 호스트입니다.")
             }
     )

--- a/src/main/java/com/pickple/server/api/host/domain/Host.java
+++ b/src/main/java/com/pickple/server/api/host/domain/Host.java
@@ -51,4 +51,13 @@ public class Host extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "host", cascade = CascadeType.REMOVE)
     private List<Moim> moims = new ArrayList<>();
+
+    public void updateHostProfile(String imageUrl, String nickname, String userKeyword, String description,
+                                  String link) {
+        this.imageUrl = imageUrl;
+        this.nickname = nickname;
+        this.userKeyword = userKeyword;
+        this.description = description;
+        this.link = link;
+    }
 }

--- a/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.pickple.server.api.host.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record HostUpdateRequest(
+        String profileUrl,
+
+        @Size(max = 50)
+        @NotBlank(message = "닉네임이 비어있습니다.")
+        String nickname,
+
+        @Size(max = 50)
+        @NotBlank(message = "호칭이 비어있습니다.")
+        String keyword,
+
+        @Size(max = 70)
+        @NotBlank(message = "소개글이 비어있습니다.")
+        String description,
+
+        @Size(max = 50)
+        @NotBlank(message = "소셜 링크가 비어있습니다.")
+        String socialLink
+) {
+}

--- a/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record HostUpdateRequest(
+
+        @NotBlank(message = "이미지가 비어있습니다.")
         String profileUrl,
 
         @Size(max = 50)

--- a/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
@@ -1,0 +1,35 @@
+package com.pickple.server.api.host.service;
+
+
+import com.pickple.server.api.guest.repository.GuestRepository;
+import com.pickple.server.api.host.domain.Host;
+import com.pickple.server.api.host.dto.request.HostUpdateRequest;
+import com.pickple.server.api.host.repository.HostRepository;
+import com.pickple.server.api.submitter.repository.SubmitterRepository;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HostCommandService {
+
+    private final HostRepository hostRepository;
+    private final GuestRepository guestRepository;
+    private final SubmitterRepository submitterRepository;
+
+    public void updateHostProfile(Long hostId, HostUpdateRequest hostUpdateRequest) {
+        Host host = hostRepository.findHostByIdOrThrow(hostId);
+        if (hostRepository.existsByNickname(hostUpdateRequest.nickname()) || guestRepository.existsByNickname(
+                hostUpdateRequest.nickname()) || submitterRepository.existsByNickname(hostUpdateRequest.nickname())) {
+            throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
+        }
+        host.updateHostProfile(hostUpdateRequest.profileUrl(), hostUpdateRequest.nickname(),
+                hostUpdateRequest.keyword(),
+                hostUpdateRequest.description(), hostUpdateRequest.socialLink());
+
+    }
+}

--- a/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java
@@ -9,7 +9,7 @@ public enum S3BucketDirectory {
     MOIM_PREFIX("moim/"),
     NOTICE_PREFIX("notice/"),
     REVIEW_PREFIX("review/"),
-    ;
+    HOST_PREFIX("host/");
 
     private final String name;
 

--- a/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java
+++ b/src/main/java/com/pickple/server/global/common/external/s3/S3BucketDirectory.java
@@ -9,7 +9,7 @@ public enum S3BucketDirectory {
     MOIM_PREFIX("moim/"),
     NOTICE_PREFIX("notice/"),
     REVIEW_PREFIX("review/"),
-    HOST_PREFIX("host/");
+    HOST_PROFILE_PREFIX("host/");
 
     private final String name;
 

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -44,6 +44,7 @@ public enum SuccessCode {
     COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20032, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
     MOIM_SUBMISSION_ALL_GET_SUCCESS(20033, HttpStatus.OK, "모임 참여 신청 전체 조회 성공"),
     GUEST_PROFILE_UPDATE_SUCCESS(20034, HttpStatus.OK, "게스트 프로필 수정 성공"),
+    HOST_PROFILE_UPDATE_SUCCESS(20035, HttpStatus.OK, "호스트 프로필 수정 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #174 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 프로필 수정 API 구현
  - 닉네임 중복 검사 로직을 구현했습니다.
  - S3에 HOST_PREFIX 경로를 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 버스코딩하다가 토할뻔했어요

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="624" alt="스크린샷 2024-08-30 오후 3 51 53" src="https://github.com/user-attachments/assets/db6ab405-3ac7-40c3-81b4-952d87e73b31">