### PR TITLE
[feat] 호스트에 해당하는 리뷰 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -36,4 +36,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
     @Query("SELECT COUNT(m) FROM Moim m WHERE m.host.id = :hostId AND m.moimState = 'completed'")
     int CompletedMoimNumber(Long hostId);
 
+    List<Moim> findMoimByHostId(Long hostId);
 }

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -8,7 +8,6 @@ import com.pickple.server.api.notice.dto.response.NoticeDetailGetResponse;
 import com.pickple.server.api.notice.dto.response.NoticeListGetByMoimResponse;
 import com.pickple.server.api.notice.repository.NoticeRepository;
 import com.pickple.server.global.util.DateTimeUtil;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +52,7 @@ public class NoticeQueryService {
                 .title(notice.getTitle())
                 .content(notice.getContent())
                 .noticeImageUrl(notice.getImageUrl())
-                .dateTime(notice.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")))
+                .dateTime(DateTimeUtil.refineDateAndTime(notice.getCreatedAt()))
                 .commentNumber(commentRepository.countCommentByNoticeId(noticeId))
                 .isPrivate(notice.isPrivate())
                 .isOwner(checkOwner(userId, moim.getId()))

--- a/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
+++ b/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
@@ -1,9 +1,15 @@
 package com.pickple.server.api.review.Service;
 
+import com.pickple.server.api.moim.domain.Moim;
+import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.review.domain.enums.HostTag;
 import com.pickple.server.api.review.domain.enums.MoimTag;
+import com.pickple.server.api.review.dto.response.ReviewListGetByHostResponse;
 import com.pickple.server.api.review.dto.response.TagListGetResponse;
+import com.pickple.server.api.review.repository.ReviewRepository;
+import com.pickple.server.global.util.DateTimeUtil;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewQueryService {
+
+    private final MoimRepository moimRepository;
+    private final ReviewRepository reviewRepository;
+
     public TagListGetResponse getAllTags() {
         return TagListGetResponse.builder()
                 .moimTag(Arrays.stream(MoimTag.values())
@@ -22,5 +32,24 @@ public class ReviewQueryService {
                         .map(HostTag::getDescription)
                         .collect(Collectors.toList()))
                 .build();
+    }
+
+    public List<ReviewListGetByHostResponse> getReviewListByHost(Long hostId) {
+        List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
+
+        return moimList.stream()
+                .flatMap(oneMoim -> reviewRepository.findReviewByMoimId(oneMoim.getId()).stream()
+                        .map(review -> ReviewListGetByHostResponse.builder()
+                                .moimId(oneMoim.getId())
+                                .moimTitle(oneMoim.getTitle())
+                                .tagList(review.getTagList())
+                                .content(review.getContent())
+                                .reviewImageUrl(review.getImageUrl())
+                                .guestNickname(review.getGuest().getNickname())
+                                .guestImageUrl(review.getGuest()
+                                        .getImageUrl())
+                                .date(DateTimeUtil.refineDateAndTime(review.getCreatedAt()))
+                                .build()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pickple/server/api/review/controller/ReviewController.java
+++ b/src/main/java/com/pickple/server/api/review/controller/ReviewController.java
@@ -3,11 +3,13 @@ package com.pickple.server.api.review.controller;
 import com.pickple.server.api.review.Service.ReviewCommandService;
 import com.pickple.server.api.review.Service.ReviewQueryService;
 import com.pickple.server.api.review.dto.request.ReviewCreateReqeust;
+import com.pickple.server.api.review.dto.response.ReviewListGetByHostResponse;
 import com.pickple.server.api.review.dto.response.TagListGetResponse;
 import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.response.ApiResponseDto;
 import com.pickple.server.global.response.enums.SuccessCode;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,5 +39,13 @@ public class ReviewController implements ReviewControllerDocs {
     ) {
         reviewCommandService.createReview(moimId, guestId, reviewCreateRequest);
         return ApiResponseDto.success(SuccessCode.REVIEW_CREATE_SUCCESS);
+    }
+
+    @GetMapping("/v2/host/{hostId}/review-list")
+    public ApiResponseDto<List<ReviewListGetByHostResponse>> getReviewListByHost(
+            @PathVariable("hostId") final Long hostId
+    ) {
+        return ApiResponseDto.success(SuccessCode.REVIEW_LIST_BY_HOST_GET_SUCCESS,
+                reviewQueryService.getReviewListByHost(hostId));
     }
 }

--- a/src/main/java/com/pickple/server/api/review/controller/ReviewControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/review/controller/ReviewControllerDocs.java
@@ -1,8 +1,10 @@
 package com.pickple.server.api.review.controller;
 
 import com.pickple.server.api.review.dto.request.ReviewCreateReqeust;
+import com.pickple.server.api.review.dto.response.ReviewListGetByHostResponse;
 import com.pickple.server.api.review.dto.response.TagListGetResponse;
 import com.pickple.server.global.common.annotation.GuestId;
+import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -39,5 +42,18 @@ public interface ReviewControllerDocs {
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
             @GuestId final Long guestId,
             @RequestBody ReviewCreateReqeust reviewCreateReqeust
+    );
+
+    @Operation(summary = "호스트에 해당하는 리뷰 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20037", description = "호스트에 해당하는 리뷰 조회 성공"),
+                    @ApiResponse(responseCode = "40404", description = "존재하지 않는 모임입니다."),
+                    @ApiResponse(responseCode = "40405", description = "존재하지 않는 호스트입니다.")
+            }
+    )
+    ApiResponseDto<List<ReviewListGetByHostResponse>> getReviewListByHost(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
+            @HostId final Long hostId
     );
 }

--- a/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByHostResponse.java
+++ b/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByHostResponse.java
@@ -1,0 +1,17 @@
+package com.pickple.server.api.review.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ReviewListGetByHostResponse(
+        Long moimId,    //moimId
+        String moimTitle,    //moim 제목
+        List tagList,    //
+        String content,    //리뷰 내용
+        String reviewImageUrl,    //리뷰 이미지
+        String guestNickname,    //리뷰 작성자(게스트) 닉네임
+        String guestImageUrl,    //리뷰 작성자(게스트) 프로필 이미지
+        String date    //리뷰 작성 일자
+) {
+}

--- a/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
@@ -1,8 +1,11 @@
 package com.pickple.server.api.review.repository;
 
 import com.pickple.server.api.review.domain.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
+
+    List<Review> findReviewByMoimId(Long moimId);
 }

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -44,6 +44,7 @@ public enum SuccessCode {
     COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20032, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
     MOIM_SUBMISSION_ALL_GET_SUCCESS(20033, HttpStatus.OK, "모임 참여 신청 전체 조회 성공"),
     GUEST_PROFILE_UPDATE_SUCCESS(20034, HttpStatus.OK, "게스트 프로필 수정 성공"),
+    REVIEW_LIST_BY_HOST_GET_SUCCESS(20035, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 api 구현"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -44,7 +44,7 @@ public enum SuccessCode {
     COMMENT_LIST_BY_NOTICE_GET_SUCCESS(20032, HttpStatus.OK, "공지사항에 해당하는 댓글 전체 조회 성공"),
     MOIM_SUBMISSION_ALL_GET_SUCCESS(20033, HttpStatus.OK, "모임 참여 신청 전체 조회 성공"),
     GUEST_PROFILE_UPDATE_SUCCESS(20034, HttpStatus.OK, "게스트 프로필 수정 성공"),
-    REVIEW_LIST_BY_HOST_GET_SUCCESS(20035, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 api 구현"),
+    REVIEW_LIST_BY_HOST_GET_SUCCESS(20037, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #175

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트에 해당하는 리뷰 전체 조회 api를 구현했습니다.
- hostId로 호스트에 해당하는 moim을 찾아와 리스트에 담았고 해당하는 모임에 작성된 리뷰를 불러왔습니다.
   이 과정에서 아래와 같이 2개의 리스트를 구현하려고 했으나 [flatMap](https://devjem.tistory.com/41)을 사용하여 moim만을 담는 리스트 하나만 구현햇습니다.
   ```
   .flatMap(oneMoim -> reviewRepository.findReviewByMoimId(oneMoim.getId()).stream()
   .map(review -> ReviewListGetByHostResponse.builder()
   ```

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-08-30 오후 5 36 24" src="https://github.com/user-attachments/assets/760ab41d-010d-44dd-a4ea-48e20103dde7">
