### PR TITLE
[fix] 모임 상태 전환 스케줄러 시간 변경

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -7,9 +7,9 @@ import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.global.util.DateUtil;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -51,7 +51,7 @@ public class MoimCommandService {
     @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
-        String formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        String formattedDate = DateUtil.refineDate(date);
         List<Moim> moimList = moimRepository.findByDate(formattedDate);
 
         for (Moim moim : moimList) {

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -48,7 +48,7 @@ public class MoimCommandService {
     }
 
     //1분마다 실행
-    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
         String formattedDate = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -47,7 +47,7 @@ public class MoimCommandService {
                 .build();
     }
 
-    //1분마다 실행
+    //정각마다 실행
     @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();

--- a/src/main/java/com/pickple/server/global/util/DateUtil.java
+++ b/src/main/java/com/pickple/server/global/util/DateUtil.java
@@ -1,6 +1,7 @@
 package com.pickple.server.global.util;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 public class DateUtil {
@@ -15,5 +16,10 @@ public class DateUtil {
         LocalDate today = LocalDate.now();
         int day = (int) ChronoUnit.DAYS.between(today, date);
         return day;
+    }
+
+    public static String refineDate(LocalDate localDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return localDate.format(formatter);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #182 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 상태 전환 스케줄러 시간 변경 
  - 스케줄러의 동작 시간을 1분에서 1시간 단위로 변경했습니다.
  - dateformat을 리팩토링했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="858" alt="스크린샷 2024-09-02 오후 10 48 28" src="https://github.com/user-attachments/assets/62635123-379c-40a7-919e-ef5c2661bacb">
<img width="717" alt="스크린샷 2024-09-02 오후 11 06 40" src="https://github.com/user-attachments/assets/d775eacf-f0f5-462f-9a47-ba68bee693e3">
