### PR TITLE
[feat] 리뷰 작성 시 모임 정보 조회 API

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -6,6 +6,7 @@ import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
+import com.pickple.server.api.moim.dto.response.MoimGetResponse;
 import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
@@ -84,5 +85,11 @@ public class MoimController implements MoimControllerDocs {
                                                                                @RequestParam String moimState) {
         return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST,
                 moimQueryService.getMoimListByHost(hostId, moimState));
+    }
+
+    @GetMapping("/v2/moim/{moimId}/review")
+    public ApiResponseDto<MoimGetResponse> getMoimForReview(@PathVariable Long moimId) {
+        return ApiResponseDto.success(SuccessCode.MOIM_FOR_REVIEW_GET_SUCCESS,
+                moimQueryService.getMoimForReview(moimId));
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
@@ -2,6 +2,7 @@ package com.pickple.server.api.moim.controller;
 
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
+import com.pickple.server.api.moim.dto.response.MoimGetResponse;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.response.ApiResponseDto;
@@ -114,5 +115,16 @@ public interface MoimControllerDocs {
     ApiResponseDto getMoimListByHostId(
             @PathVariable Long hostId,
             @RequestParam String moimState
+    );
+
+    @Operation(summary = "리뷰 작성 시 모임 정보 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20039", description = "리뷰 작성 시 모임 정보 조회 성공"),
+                    @ApiResponse(responseCode = "40404", description = "존재하지 않는 모임입니다.")
+            }
+    )
+    ApiResponseDto<MoimGetResponse> getMoimForReview(
+            @PathVariable Long moimId
     );
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record MoimGetResponse(
+
         String title,
 
         String moimImage,

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
@@ -7,6 +7,10 @@ import lombok.Builder;
 public record MoimGetResponse(
         String title,
 
+        String moimImage,
+
+        String hostImage,
+
         String hostNickname,
 
         DateInfo dateList

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimGetResponse.java
@@ -1,0 +1,14 @@
+package com.pickple.server.api.moim.dto.response;
+
+import com.pickple.server.api.moim.domain.DateInfo;
+import lombok.Builder;
+
+@Builder
+public record MoimGetResponse(
+        String title,
+
+        String hostNickname,
+
+        DateInfo dateList
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -6,6 +6,7 @@ import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
+import com.pickple.server.api.moim.dto.response.MoimGetResponse;
 import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
@@ -122,5 +123,15 @@ public class MoimQueryService {
         return Arrays.stream(Category.values())
                 .map(category -> category.category)
                 .collect(Collectors.toList());
+    }
+
+    public MoimGetResponse getMoimForReview(Long moimId) {
+        Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
+
+        return MoimGetResponse.builder()
+                .title(moim.getTitle())
+                .hostNickname(moim.getHost().getNickname())
+                .dateList(moim.getDateList())
+                .build();
     }
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -130,6 +130,8 @@ public class MoimQueryService {
 
         return MoimGetResponse.builder()
                 .title(moim.getTitle())
+                .moimImage(moim.getImageList().getImageUrl1())
+                .hostImage(moim.getHost().getImageUrl())
                 .hostNickname(moim.getHost().getNickname())
                 .dateList(moim.getDateList())
                 .build();

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -48,6 +48,7 @@ public enum SuccessCode {
     COMMENT_DELETE_SUCCESS(20036, HttpStatus.OK, "공지사항 댓글 삭제 성공"),
     REVIEW_LIST_BY_MOIM_GET_SUCCESS(20037, HttpStatus.OK, "모임에 해당하는 리뷰 조회 성공"),
     REVIEW_LIST_BY_HOST_GET_SUCCESS(20038, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 성공"),
+    MOIM_FOR_REVIEW_GET_SUCCESS(20039, HttpStatus.OK, "리뷰 작성 시 모임 정보 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -48,7 +48,6 @@ public enum SuccessCode {
     COMMENT_DELETE_SUCCESS(20036, HttpStatus.OK, "공지사항 댓글 삭제 성공"),
     REVIEW_LIST_BY_MOIM_GET_SUCCESS(20037, HttpStatus.OK, "모임에 해당하는 리뷰 조회 성공"),
     REVIEW_LIST_BY_HOST_GET_SUCCESS(20038, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 성공"),
-    MOIM_FOR_REVIEW_GET_SUCCESS(20039, HttpStatus.OK, "리뷰 작성 시 모임 정보 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #190

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 리뷰 작성 시 모임 정보 조회
  - 리뷰를 작성하는 모임의 정보를 조회합니다.
  - 스웨거에 명세서 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 리뷰 작성 시 쓰는 거라 엔드포인트에 review를 추가하긴 했는데 뭔가 이렇게 쓰는 게 맞는지 잘 모르겠습니다.
- 노션에 [명세서](https://super-wildcat-183.notion.site/API-ffcbafce9e7e43ca8661cd4154472660?pvs=4) 작성해두었습니다.
## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="635" alt="스크린샷 2024-09-05 오후 10 24 56" src="https://github.com/user-attachments/assets/2efea9cd-edc1-4dc4-8999-906380660fa7">
