### PR TITLE
[feat] 호스트에 해당하는 모임 조회 api 구현

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/request/CommentCreateRequest.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.comment.dto.request;
 
 public record CommentCreateRequest(
+
         String commentContent
 ) {
 }

--- a/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record CommentGetResponse(
+
         boolean isOwner,
 
         String commenterImageUrl,

--- a/src/main/java/com/pickple/server/api/guest/dto/request/GuestUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/guest/dto/request/GuestUpdateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record GuestUpdateRequest(
+
         @Size(max = 15)
         @NotBlank(message = "닉네임이 비어있습니다.")
         String guestNickname

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostByMoimResponse.java
@@ -4,10 +4,15 @@ import lombok.Builder;
 
 @Builder
 public record HostByMoimResponse(
+
         String hostNickName,    // 호스트 닉네임
+
         String hostImageUrl,    // 호스트 프로필 사진 url
+
         int count,           // 호스트의 모임 횟수(두자릿수)
+
         String keyword,
+
         String description
 ) {
 }

--- a/src/main/java/com/pickple/server/api/host/dto/response/HostIntroGetResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/HostIntroGetResponse.java
@@ -4,11 +4,17 @@ import lombok.Builder;
 
 @Builder
 public record HostIntroGetResponse(
+
         String nickName,    // 호스트 닉네임
+
         String profileUrl,    // 호스트 프로필 사진 url
+
         int count,           // 호스트의 모임 횟수(두자릿수)
+
         String keyword,
+
         String description,
+
         String socialLink
 ) {
 }

--- a/src/main/java/com/pickple/server/api/host/dto/response/SubmittionDetailResponse.java
+++ b/src/main/java/com/pickple/server/api/host/dto/response/SubmittionDetailResponse.java
@@ -6,7 +6,9 @@ import lombok.Builder;
 
 @Builder
 public record SubmittionDetailResponse(
+
         QuestionInfo questionList,
+
         AnswerInfo answerList
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -6,7 +6,7 @@ import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
-import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostAndMoimStateGetResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
@@ -80,9 +80,11 @@ public class MoimController implements MoimControllerDocs {
     }
 
     @GetMapping("/v1/host/{hostId}/moim-list")
-    public ApiResponseDto<List<MoimListByHostGetResponse>> getMoimListByHostId(@PathVariable Long hostId,
-                                                                               @RequestParam String moimState) {
-        return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST,
-                moimQueryService.getMoimListByHost(hostId, moimState));
+    public ApiResponseDto<List<MoimListByHostAndMoimStateGetResponse>> getMoimListByHostAndMoimState(
+            @PathVariable Long hostId,
+            @RequestParam String moimState) {
+        return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST_AND_MOIMSTATE,
+                moimQueryService.getMoimListByHostAndMoimState(hostId, moimState));
     }
+
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimController.java
@@ -7,6 +7,7 @@ import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.dto.response.MoimListByHostAndMoimStateGetResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.service.MoimCommandService;
 import com.pickple.server.api.moim.service.MoimQueryService;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
@@ -87,4 +88,9 @@ public class MoimController implements MoimControllerDocs {
                 moimQueryService.getMoimListByHostAndMoimState(hostId, moimState));
     }
 
+    @GetMapping("/v2/host/{hostId}/moim-list")
+    public ApiResponseDto<List<MoimListByHostGetResponse>> getMoimListByHost(@PathVariable Long hostId) {
+        return ApiResponseDto.success(SuccessCode.MOIM_LIST_BY_HOST,
+                moimQueryService.getMoimListByHost(hostId));
+    }
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
@@ -116,4 +116,14 @@ public interface MoimControllerDocs {
             @RequestParam String moimState
     );
 
+    @Operation(summary = "호스트에 해당하는 모임 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20040", description = "호스트에 해당하는 모임 조회 성공"),
+                    @ApiResponse(responseCode = "40408", description = "호스트에 해당하는 모임이 없습니다.")
+            }
+    )
+    ApiResponseDto getMoimListByHost(
+            @PathVariable Long hostId
+    );
 }

--- a/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/moim/controller/MoimControllerDocs.java
@@ -104,15 +104,16 @@ public interface MoimControllerDocs {
     )
     ApiResponseDto getMoimBanner();
 
-    @Operation(summary = "호스트에 해당하는 모임 조회")
+    @Operation(summary = "호스트와 모임상태에 해당하는 모임 조회")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "20023", description = "호스트에 해당하는 모임 조회 성공"),
+                    @ApiResponse(responseCode = "20023", description = "호스트와 모임상태에 해당하는 모임 조회 성공"),
                     @ApiResponse(responseCode = "40408", description = "호스트와 상태에 해당하는 모임이 없습니다.")
             }
     )
-    ApiResponseDto getMoimListByHostId(
+    ApiResponseDto getMoimListByHostAndMoimState(
             @PathVariable Long hostId,
             @RequestParam String moimState
     );
+
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/request/MoimCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/request/MoimCreateRequest.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 public record MoimCreateRequest(
+
         @Valid
         CategoryInfo categoryList,
 

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimCreateResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimCreateResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record MoimCreateResponse(
+
         Long moimId
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimDescriptionResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimDescriptionResponse.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record MoimDescriptionResponse(
+
         String description
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimDetailResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimDetailResponse.java
@@ -6,14 +6,23 @@ import lombok.Builder;
 
 @Builder
 public record MoimDetailResponse(
+
         int dayOfDay,
+
         String title,
+
         DateInfo dateList,
+
         boolean isOffline,
+
         String spot,
+
         int maxGuest,
+
         int fee,
+
         ImageInfo imageList,
+
         Long hostId
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostAndMoimStateGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostAndMoimStateGetResponse.java
@@ -3,7 +3,7 @@ package com.pickple.server.api.moim.dto.response;
 import lombok.Builder;
 
 @Builder
-public record MoimListByHostGetResponse(
+public record MoimListByHostAndMoimStateGetResponse(
         Long moimId,            //모임 id
         String title,          //모임 제목
         Long approvedGuest,     //승인된 인원

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostAndMoimStateGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostAndMoimStateGetResponse.java
@@ -4,10 +4,15 @@ import lombok.Builder;
 
 @Builder
 public record MoimListByHostAndMoimStateGetResponse(
+
         Long moimId,            //모임 id
+
         String title,          //모임 제목
+
         Long approvedGuest,     //승인된 인원
+
         int maxGuest,          //최대 참가인원
+
         String moimImage       //모임 대표 이미지
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostGetResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/MoimListByHostGetResponse.java
@@ -1,0 +1,23 @@
+package com.pickple.server.api.moim.dto.response;
+
+import com.pickple.server.api.moim.domain.DateInfo;
+import lombok.Builder;
+
+@Builder
+public record MoimListByHostGetResponse(
+
+        Long moimId,
+
+        int dayOfDay,
+
+        String title,
+
+        String hostNickName,
+
+        DateInfo dateList,
+
+        String moimImageUrl,
+
+        String hostImageUrl
+) {
+}

--- a/src/main/java/com/pickple/server/api/moim/dto/response/SubmittedMoimByGuestResponse.java
+++ b/src/main/java/com/pickple/server/api/moim/dto/response/SubmittedMoimByGuestResponse.java
@@ -5,13 +5,21 @@ import lombok.Builder;
 
 @Builder
 public record SubmittedMoimByGuestResponse(
+
         Long moimId,
+
         String moimSubmissionState,
+
         String title,
+
         String hostNickname,
+
         DateInfo dateList,
+
         int fee,
+
         String imageUrl,
+
         boolean isReviewed
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -6,7 +6,7 @@ import com.pickple.server.api.moim.domain.enums.Category;
 import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
-import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostAndMoimStateGetResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
@@ -95,11 +95,11 @@ public class MoimQueryService {
         return moimIdList.get(randomIndex);
     }
 
-    public List<MoimListByHostGetResponse> getMoimListByHost(Long hostId, String moimState) {
+    public List<MoimListByHostAndMoimStateGetResponse> getMoimListByHostAndMoimState(Long hostId, String moimState) {
         List<Moim> moimList = moimRepository.findMoimByhostIdAndMoimState(hostId, moimState);
 
         return moimList.stream()
-                .map(oneMoim -> MoimListByHostGetResponse.builder()
+                .map(oneMoim -> MoimListByHostAndMoimStateGetResponse.builder()
                         .moimId(oneMoim.getId())
                         .moimImage(oneMoim.getImageList().getImageUrl1())
                         .approvedGuest(calculateApprovedGuest(oneMoim.getId()))
@@ -108,6 +108,7 @@ public class MoimQueryService {
                         .build())
                 .collect(Collectors.toList());
     }
+
 
     private Long calculateApprovedGuest(Long moimId) {
         try {

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -7,6 +7,7 @@ import com.pickple.server.api.moim.dto.response.MoimByCategoryResponse;
 import com.pickple.server.api.moim.dto.response.MoimDescriptionResponse;
 import com.pickple.server.api.moim.dto.response.MoimDetailResponse;
 import com.pickple.server.api.moim.dto.response.MoimListByHostAndMoimStateGetResponse;
+import com.pickple.server.api.moim.dto.response.MoimListByHostGetResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.dto.response.MoimByGuestResponse;
 import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
@@ -109,6 +110,21 @@ public class MoimQueryService {
                 .collect(Collectors.toList());
     }
 
+    public List<MoimListByHostGetResponse> getMoimListByHost(Long hostId) {
+        List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
+
+        return moimList.stream()
+                .map(oneMoim -> MoimListByHostGetResponse.builder()
+                        .moimId(oneMoim.getId())
+                        .dayOfDay(DateUtil.calculateDayOfDay(oneMoim.getDateList().getDate()))
+                        .title(oneMoim.getTitle())
+                        .hostNickName(oneMoim.getHost().getNickname())
+                        .dateList(oneMoim.getDateList())
+                        .moimImageUrl(oneMoim.getImageList().getImageUrl1())
+                        .hostImageUrl(oneMoim.getHost().getImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
 
     private Long calculateApprovedGuest(Long moimId) {
         try {

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitRequest.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitRequest.java
@@ -7,8 +7,10 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 public record MoimSubmitRequest(
+
         @Valid
         AnswerInfo answerList,
+
         AccountInfo accountList
 ) {
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/dto/request/MoimSubmitterUpdateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record MoimSubmitterUpdateRequest(
+
         @NotNull
         List<Long> submitterIdList
 ) {

--- a/src/main/java/com/pickple/server/api/notice/dto/request/NoticeCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/notice/dto/request/NoticeCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record NoticeCreateRequest(
+
         @Size(max = 25, message = "제목은 최대 25자 이내로 작성해주세요.")
         @NotBlank(message = "제목 비어 있습니다.")
         String noticeTitle,//공지사항 제목

--- a/src/main/java/com/pickple/server/api/notice/dto/response/NoticeDetailGetResponse.java
+++ b/src/main/java/com/pickple/server/api/notice/dto/response/NoticeDetailGetResponse.java
@@ -4,14 +4,23 @@ import lombok.Builder;
 
 @Builder
 public record NoticeDetailGetResponse(
+
         String hostImageUrl,
+
         String hostNickname,
+
         String title,
+
         String content,
+
         String noticeImageUrl,
+
         String dateTime,
+
         int commentNumber,
+
         boolean isPrivate,
+
         boolean isOwner
 ) {
 }

--- a/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/notice/dto/response/NoticeListGetByMoimResponse.java
@@ -4,14 +4,23 @@ import lombok.Builder;
 
 @Builder
 public record NoticeListGetByMoimResponse(
+
         Long noticeId,          //공지사항id
+
         String hostNickName,    //호스트 닉네임
+
         String hostImageUrl,    //호스트 이미지
+
         String title,           //공지사항 제목
+
         String content,         //공지사항 내용
+
         String date,            //공지사항 등록 일자 및 시간 yyyy.mm.dd hh:mm:ss
+
         String noticeImageUrl,  //공지사항 이미지
+
         Long hostId,             //호스트 id
+
         int commentNumber
 ) {
 }

--- a/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByHostResponse.java
+++ b/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByHostResponse.java
@@ -5,13 +5,21 @@ import lombok.Builder;
 
 @Builder
 public record ReviewListGetByHostResponse(
+
         Long moimId,    //moimId
+
         String moimTitle,    //moim 제목
+
         List tagList,    //
+
         String content,    //리뷰 내용
+
         String reviewImageUrl,    //리뷰 이미지
+
         String guestNickname,    //리뷰 작성자(게스트) 닉네임
+
         String guestImageUrl,    //리뷰 작성자(게스트) 프로필 이미지
+
         String date    //리뷰 작성 일자
 ) {
 }

--- a/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByMoimResponse.java
+++ b/src/main/java/com/pickple/server/api/review/dto/response/ReviewListGetByMoimResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record ReviewListGetByMoimResponse(
+
         List tagList,
 
         String content,    //리뷰 내용
@@ -14,7 +15,7 @@ public record ReviewListGetByMoimResponse(
         String guestNickname,    //리뷰 작성자(게스트) 닉네임
 
         String guestImageUrl,    //리뷰 작성자(게스트) 프로필 이미지
-        
+
         String date    //리뷰 작성 일자
 ) {
 }

--- a/src/main/java/com/pickple/server/api/review/dto/response/TagListGetResponse.java
+++ b/src/main/java/com/pickple/server/api/review/dto/response/TagListGetResponse.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 
 @Builder
 public record TagListGetResponse(
+
         List<String> moimTag,
+
         List<String> hostTag
 ) {
 }

--- a/src/main/java/com/pickple/server/api/submitter/dto/request/SubmitterCreateRequest.java
+++ b/src/main/java/com/pickple/server/api/submitter/dto/request/SubmitterCreateRequest.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 public record SubmitterCreateRequest(
+
         @Size(max = 300, message = "소개글은 최대 300자 이내로 작성해주세요.")
         @NotBlank(message = "소개글이 비어 있습니다.")
         String intro,      //관리자에게 보여질 intro

--- a/src/main/java/com/pickple/server/api/user/dto/AccessTokenGetSuccess.java
+++ b/src/main/java/com/pickple/server/api/user/dto/AccessTokenGetSuccess.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.user.dto;
 
 public record AccessTokenGetSuccess(
+
         String accessToken
 ) {
     public static AccessTokenGetSuccess of(

--- a/src/main/java/com/pickple/server/api/user/dto/LoginSuccessResponse.java
+++ b/src/main/java/com/pickple/server/api/user/dto/LoginSuccessResponse.java
@@ -1,10 +1,15 @@
 package com.pickple.server.api.user.dto;
 
 public record LoginSuccessResponse(
+
         String guestNickname,
+
         Long guestId,
+
         String hostNickname,
+
         Long hostId,
+
         TokenDto token
 ) {
     public static LoginSuccessResponse of(

--- a/src/main/java/com/pickple/server/api/user/dto/TokenDto.java
+++ b/src/main/java/com/pickple/server/api/user/dto/TokenDto.java
@@ -1,7 +1,9 @@
 package com.pickple.server.api.user.dto;
 
 public record TokenDto(
+
         String accessToken,
+
         String refreshToken
 ) {
 

--- a/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/SuccessCode.java
@@ -32,7 +32,7 @@ public enum SuccessCode {
     COMPLETED_MOIM_LIST_BY_GUEST_GET_SUCCESS(20020, HttpStatus.OK, "게스트에 해당하는 참가한 모임 리스트 조회 성공"),
     SUBMITTER_LIST_BY_MOIM_GET_SUCCESS(20021, HttpStatus.OK, "모임에 해당하는 신청자 전체 조회 성공"),
     MOIM_SUBMITTER_APPROVE_SUCCESS(20022, HttpStatus.OK, "모임 신청자 승인 성공"),
-    MOIM_LIST_BY_HOST(20023, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
+    MOIM_LIST_BY_HOST_AND_MOIMSTATE(20023, HttpStatus.OK, "호스트와 모임상태에 해당하는 모임 조회 성공"),
     SUBMITTER_LIST_GET_SUCCESS(20024, HttpStatus.OK, "호스트 승인 신청 내역 조회 성공"),
     HOST_SUBMITTER_APPROVE_SUCCESS(20025, HttpStatus.OK, "호스트 신청자 승인 성공"),
     NOTICE_DELETE_SUCCESS(20026, HttpStatus.OK, "공지사항 삭제 성공"),
@@ -48,6 +48,8 @@ public enum SuccessCode {
     COMMENT_DELETE_SUCCESS(20036, HttpStatus.OK, "공지사항 댓글 삭제 성공"),
     REVIEW_LIST_BY_MOIM_GET_SUCCESS(20037, HttpStatus.OK, "모임에 해당하는 리뷰 조회 성공"),
     REVIEW_LIST_BY_HOST_GET_SUCCESS(20038, HttpStatus.OK, "호스트에 해당하는 리뷰 전체 조회 성공"),
+
+    MOIM_LIST_BY_HOST(20040, HttpStatus.OK, "호스트에 해당하는 모임 조회 성공"),
 
     // 201 Created
     MOIM_CREATE_SUCCESS(20100, HttpStatus.CREATED, "모임 개설 성공"),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #192 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
호스트에 해당하는 모임 조회 api를 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 기존 api가 호스트와 모임상태에 해당하는 모임 조회인데 명칭이 호스트에 해당하는 모임조회로 되어있어서 혼란이 있었습니다.
그래서 기존 api [명세서](https://www.notion.so/API-02e88c30d2ed44688c01c8e431f91e0c?pvs=4)에 명칭을 변경하였고 코드도 수정하였습니다.
- 현 api response와 카테고리에 해당하는 모임조회, 리뷰 작성 시 모임 조회 등등 모임 카드에 필요한 response가 동일합니다.
이번 스프린트 끝나고 기획측에 카드정보가 뷰마다 달라질 상황이 발생할 수 있는지 확인 후 발생하지 않을 것 같다고 한다면 response를 하나로 통일하는 것이 좋을것같습니다. 우선 need to refactor 붙여두겠습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-09-06 오전 11 04 45" src="https://github.com/user-attachments/assets/c97ecf3c-56bc-40d0-8b7b-beb101fc7124">