### PR TITLE
[fix] 댓글 전체 조회 시 response에 댓글 Id값 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 @Builder
 public record CommentGetResponse(
 
+        Long commentId,
+
         boolean isOwner,
 
         String commenterImageUrl,

--- a/src/main/java/com/pickple/server/api/comment/service/CommentQueryService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentQueryService.java
@@ -27,7 +27,8 @@ public class CommentQueryService {
     private final GuestRepository guestRepository;
 
     public List<CommentGetResponse> getCommentListByNotice(Long noticeId) {
-        List<Comment> commentList = commentRepository.findCommentsByNoticeId(noticeId);
+        Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
+        List<Comment> commentList = commentRepository.findCommentsByNoticeId(notice.getId());
         return commentList.stream().map(comment -> {
                     boolean isOwner = checkOwner(comment.getCommenter().getId(), noticeId);
                     return buildCommentGetResponse(comment, checkOwner(comment.getCommenter().getId(), noticeId),
@@ -38,6 +39,7 @@ public class CommentQueryService {
 
     private CommentGetResponse buildCommentGetResponse(Comment comment, boolean isOwner, CommenterInfo commenterInfo) {
         return CommentGetResponse.builder()
+                .commentId(comment.getId())
                 .isOwner(isOwner)
                 .commenterImageUrl(commenterInfo.getProfileImageUrl())
                 .commenterNickname(commenterInfo.getProfileNickname())


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #196

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 댓글 전체 조회 시 response에 댓글 Id값 추가했습니다.(클라 요청)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="631" alt="스크린샷 2024-09-12 오후 6 55 17" src="https://github.com/user-attachments/assets/7e88a3a2-859b-4437-8812-d1c302d48afd">
