### PR TITLE
[fix] 호스트 승인 신청 내역 조회 API 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterListGetResponse.java
+++ b/src/main/java/com/pickple/server/api/submitter/dto/response/SubmitterListGetResponse.java
@@ -1,6 +1,5 @@
 package com.pickple.server.api.submitter.dto.response;
 
-import com.pickple.server.api.submitter.domain.SubmitterCategoryInfo;
 import lombok.Builder;
 
 @Builder
@@ -18,7 +17,7 @@ public record SubmitterListGetResponse(
 
         String nickname,
 
-        SubmitterCategoryInfo categoryList,
+        String userKeyword,
 
         String plan,
 

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterQueryService.java
@@ -29,6 +29,7 @@ public class SubmitterQueryService {
                         .goal(submitter.getGoal())
                         .link(submitter.getLink())
                         .nickname(submitter.getNickname())
+                        .userKeyword(submitter.getUserKeyword())
                         .plan(submitter.getPlan())
                         .email(submitter.getEmail())
                         .submitterState(submitter.getSubmitterState())


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #198

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 승인 신청 내역 조회 API 수정
  - response에 있던 categoryList를 삭제 후 userKeyword로 변경했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="624" alt="스크린샷 2024-09-12 오후 9 49 25" src="https://github.com/user-attachments/assets/7d236867-ce0b-4f5c-a67b-83e8c01098ed">
