### PR TITLE
[fix] 게스트에 해당하는 신청한 모임 조회 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/controller/MoimSubmissionController.java
@@ -41,7 +41,7 @@ public class MoimSubmissionController implements MoimSubmissionControllerDocs {
         return ApiResponseDto.success(SuccessCode.MOIM_SUBMISSION_POST_SUCCESS);
     }
 
-    @GetMapping("/v1/guest/{guestId}/submitted-moim-list")
+    @GetMapping("/v2/guest/{guestId}/submitted-moim-list")
     public ApiResponseDto<List<SubmittedMoimByGuestResponse>> getSubmittedMoimListByGuest(
             @PathVariable Long guestId,
             @RequestParam String moimSubmissionState

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -44,4 +44,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
         return findMoimSubmissionById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND));
     }
+
+    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
+    List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -42,7 +42,7 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList;
 
         if (moimSubmissionState.equals(MoimSubmissionState.ALL.getMoimSubmissionState())) {
-            moimSubmissionList = moimSubmissionRepository.findAllByGuestId(guest.getId());
+            moimSubmissionList = moimSubmissionRepository.findAllSubmittedMoimSubmission(guest.getId());
         } else {
             moimSubmissionList = moimSubmissionRepository.findAllByGuestIdAndMoimSubmissionState(guestId,
                     moimSubmissionState);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #200 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게스트에 해당하는 신청한 모임 조회 로직 수정
  - 현재 로직은 completed(참가 완료) 상태를 포함해서 전체 조회를 내려주고 있어서 이 부분을 제외시켰습니다.
  - 엔드포인트를 v2로 변경하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="631" alt="스크린샷 2024-09-15 오후 8 07 08" src="https://github.com/user-attachments/assets/b34cfcbe-ddea-4ee5-b72c-114c36d2325c">
