### PR TITLE
[fix] 공지사항 댓글 삭제 시 호스트 삭제 권한 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
+++ b/src/main/java/com/pickple/server/api/comment/service/CommentCommandService.java
@@ -41,7 +41,9 @@ public class CommentCommandService {
         Notice notice = noticeRepository.findNoticeByIdOrThrow(noticeId);
         Comment comment = commentRepository.findCommentByIdOrThrow(commentId);
 
-        if (comment.getCommenter().getId().equals(userId)) {
+        //댓글 작성자가 사용자 본인인 경우 or 사용자가 해당 모임의 호스트인 경우 삭제 가능
+        if (comment.getCommenter().getId().equals(userId) || userId.equals(
+                notice.getMoim().getHost().getUser().getId())) {
             commentRepository.delete(comment);
         } else {
             throw new CustomException(ErrorCode.NOT_AUTHOR);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #204

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공지사항 댓글 삭제 시 호스트 삭제 권한 추가
  - 해당 모임의 호스트인 경우 자기 클래스 공지사항의 댓글을 삭제할 수 있도록 로직을 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="633" alt="스크린샷 2024-09-15 오후 8 34 53" src="https://github.com/user-attachments/assets/9ff4a651-d313-461c-bad6-5e832e8abc6b">

- 호스트 권한으로 내 모임 공지사항의 다른 유저 댓글 삭제
<img width="682" alt="스크린샷 2024-09-15 오후 8 33 52" src="https://github.com/user-attachments/assets/6cdebeec-4177-4a6b-88ad-14dc67ccd375">

<img width="678" alt="스크린샷 2024-09-15 오후 8 34 06" src="https://github.com/user-attachments/assets/e09ebe2c-af93-4913-a17d-7abe80831c6a">

