### PR TITLE
[fix] 공지사항 전체 조회 api 공개여부 로직 반영

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -12,14 +12,14 @@ import org.springframework.data.repository.query.Param;
 public interface MoimRepository extends JpaRepository<Moim, Long> {
     Optional<Moim> findMoimById(Long id);
 
-    int countByHostId(Long hostId);
-
-    List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
-
     default Moim findMoimByIdOrThrow(Long id) {
         return findMoimById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_NOT_FOUND));
     }
+
+    int countByHostId(Long hostId);
+
+    List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
 
     @Query(value = "SELECT * FROM moims WHERE EXISTS (" +
             "SELECT 1 FROM jsonb_each_text(category_list) AS categories " +
@@ -37,4 +37,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
     int CompletedMoimNumber(Long hostId);
 
     List<Moim> findMoimByHostId(Long hostId);
+
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -14,9 +14,14 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     Optional<MoimSubmission> findMoimSubmissionById(Long id);
 
+    default MoimSubmission findMoimSubmissionByIdOrThrow(Long id) {
+        return findMoimSubmissionById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND));
+    }
+
     boolean existsByMoimAndGuestId(Moim moim, Long guestId);
 
-    List<MoimSubmission> findAllByGuestId(Long guestId);
+    boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
     List<MoimSubmission> findAllByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
 
@@ -40,11 +45,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     boolean existsByMoimIdAndGuestIdAndMoimSubmissionState(Long moimId, Long guestId, String MoimSubmissionState);
 
-    default MoimSubmission findMoimSubmissionByIdOrThrow(Long id) {
-        return findMoimSubmissionById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND));
-    }
-
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
     List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
+
 }

--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeController.java
@@ -5,6 +5,7 @@ import com.pickple.server.api.notice.dto.response.NoticeDetailGetResponse;
 import com.pickple.server.api.notice.dto.response.NoticeListGetByMoimResponse;
 import com.pickple.server.api.notice.service.NoticeCommandService;
 import com.pickple.server.api.notice.service.NoticeQueryService;
+import com.pickple.server.global.common.annotation.GuestId;
 import com.pickple.server.global.common.annotation.HostId;
 import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
@@ -36,9 +37,10 @@ public class NoticeController implements NoticeControllerDocs {
     }
 
     @GetMapping("/v2/moim/{moimId}/notice-list")
-    public ApiResponseDto<List<NoticeListGetByMoimResponse>> getNoticeListByMoimId(@PathVariable Long moimId) {
+    public ApiResponseDto<List<NoticeListGetByMoimResponse>> getNoticeListByMoimId(
+            @PathVariable final Long moimId, @GuestId final Long guestId) {
         return ApiResponseDto.success(SuccessCode.NOTICE_LIST_GET_SUCCESS,
-                noticeQueryService.getNoticeListByMoimId(moimId));
+                noticeQueryService.getNoticeListByMoimId(moimId, guestId));
     }
 
     @DeleteMapping("/v2/notice/{noticeId}")

--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeControllerDocs.java
@@ -1,6 +1,10 @@
 package com.pickple.server.api.notice.controller;
 
 import com.pickple.server.api.notice.dto.request.NoticeCreateRequest;
+import com.pickple.server.api.notice.dto.response.NoticeDetailGetResponse;
+import com.pickple.server.global.common.annotation.GuestId;
+import com.pickple.server.global.common.annotation.HostId;
+import com.pickple.server.global.common.annotation.UserId;
 import com.pickple.server.global.response.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -32,6 +36,32 @@ public interface NoticeControllerDocs {
             }
     )
     ApiResponseDto getNoticeListByMoimId(
-            @PathVariable Long moimId
+            @PathVariable Long moimId,
+            @GuestId Long guestId
+    );
+
+    @Operation(summary = "공지사항 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20026", description = "공지사항 삭제 성공"),
+                    @ApiResponse(responseCode = "40409", description = "존재하지 않는 공지사항입니다.")
+            }
+    )
+    ApiResponseDto deleteNotice(
+            @HostId Long hostId,
+            @PathVariable Long noticeId
+    );
+
+    @Operation(summary = "공지사항 상세 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "20031", description = "공지사항 상세 조회 성공"),
+                    @ApiResponse(responseCode = "40409", description = "존재하지 않는 공지사항입니다.")
+            }
+    )
+    ApiResponseDto<NoticeDetailGetResponse> getNoticeDetail(
+            @UserId Long userId,
+            @PathVariable Long moimId,
+            @PathVariable Long noticeId
     );
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #206 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 공지사항 전체 조회 시 공개여부를 확인하는 로직을 구현했습니다.
   - 공지사항 전체 조회를 하는 유저의 guestId로 참가신청을 한 유저인지 확인 후 참가진청의 상태가 approved와 completd인 경우에만 참가한 유저로 판단했습니다.
   - 참가한 유저인지 판단 후 조회되는 공지사항의 공개여부를 판단하였습니다.
- 스웨거 수정 및 누락된 api의 문서화 추가했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 공지사항 상세 조회api에도 해당 로직을 추가할 예정이라 need to refactor붙였습니다!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 1번 유저로 조회( 신청이력 존재 , 신청 상태 completed )
    -  <img width="1470" alt="스크린샷 2024-09-16 오전 12 45 39" src="https://github.com/user-attachments/assets/cca92c79-487c-409f-a1ca-8c90acfca3d4">

- 1번 유저로 조회( 신청이력 존재 , 신청 상태 approved )
   - <img width="1470" alt="스크린샷 2024-09-16 오전 12 46 08" src="https://github.com/user-attachments/assets/6227e645-e635-4156-9e86-0ea8697564ec">

- 1번 유저로 조회( 신청이력 존재 , 신청 상태 rejected )
    -  <img width="1470" alt="스크린샷 2024-09-16 오전 12 46 32" src="https://github.com/user-attachments/assets/1a6abac8-2f44-4e32-9c4d-3efb396a278c">


- 1번 유저로 조회( 신청이력 미존재 )
    - <img width="1470" alt="스크린샷 2024-09-16 오전 12 46 57" src="https://github.com/user-attachments/assets/606ae037-6de7-47ab-ae9e-2f64741f4406">
