### PR TITLE
[fix] 호스트 정보 수정 API 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
+++ b/src/main/java/com/pickple/server/api/host/dto/request/HostUpdateRequest.java
@@ -20,7 +20,6 @@ public record HostUpdateRequest(
         @NotBlank(message = "소개글이 비어있습니다.")
         String description,
 
-        @Size(max = 50)
         @NotBlank(message = "소셜 링크가 비어있습니다.")
         String socialLink
 ) {

--- a/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
@@ -23,10 +23,12 @@ public class HostCommandService {
 
     public void updateHostProfile(Long hostId, HostUpdateRequest hostUpdateRequest) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
-        if (hostRepository.existsByNickname(hostUpdateRequest.nickname()) || guestRepository.existsByNickname(
-                hostUpdateRequest.nickname()) || submitterRepository.existsByNickname(hostUpdateRequest.nickname())) {
+        if (!host.getNickname().equals(hostUpdateRequest.nickname()) && (hostRepository.existsByNickname(
+                hostUpdateRequest.nickname()) || guestRepository.existsByNickname(
+                hostUpdateRequest.nickname()) || submitterRepository.existsByNickname(hostUpdateRequest.nickname()))) {
             throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
         }
+
         host.updateHostProfile(hostUpdateRequest.profileUrl(), hostUpdateRequest.nickname(),
                 hostUpdateRequest.keyword(),
                 hostUpdateRequest.description(), hostUpdateRequest.socialLink());


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #208

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 호스트 정보 수정 API 수정
  - 소셜링크의 50자 제한을 해제했습니다.
  - 현재 닉네임과 request의 닉네임이 같은 경우 중복검사 대상에서 제외했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 수정 API를 또 수정한다고 하니까 먼가 pr 이름이 요상한데 진짜수정입니다...

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 현재 닉네임과 request의 닉네임이 동일한 경우 중복 검사 대상에서 제외, 다른 부분은 정상적으로 수정됨
<img width="1395" alt="스크린샷 2024-09-16 오후 4 40 43" src="https://github.com/user-attachments/assets/cb1a89ba-5bd3-4435-93e8-206c135f9b04">

- 다른 닉네임으로 변경 시 중복 검사 정상적으로 처리됨
<img width="1371" alt="스크린샷 2024-09-16 오후 4 40 53" src="https://github.com/user-attachments/assets/45a09dc9-43ea-48e5-8fbb-bac261d7c759">

