### PR TITLE
[fix] 공지사항 전체조회 api 에러수정

### DIFF
--- a/src/main/java/com/pickple/server/api/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/pickple/server/api/notice/controller/NoticeControllerDocs.java
@@ -39,9 +39,9 @@ public interface NoticeControllerDocs {
             }
     )
     ApiResponseDto getNoticeListByMoimId(
+            @PathVariable Long moimId,
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH)
-            @GuestId Long guestId,
-            @PathVariable Long moimId
+            @GuestId Long geustId
     );
 
     @Operation(summary = "공지사항 삭제")

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.notice.service;
 
 import com.pickple.server.api.comment.repository.CommentRepository;
+import com.pickple.server.api.guest.repository.GuestRepository;
 import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
@@ -25,6 +26,7 @@ public class NoticeQueryService {
     private final NoticeRepository noticeRepository;
     private final CommentRepository commentRepository;
     private final MoimSubmissionRepository moimSubmissionRepository;
+    private final GuestRepository guestRepository;
 
     public List<NoticeListGetByMoimResponse> getNoticeListByMoimId(Long moimId, Long guestId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
@@ -71,7 +73,10 @@ public class NoticeQueryService {
     }
 
     private boolean isUserAppliedToMoim(Long moimId, Long guestId) {
-        if (moimSubmissionRepository.existsByMoimIdAndGuestId(moimId, guestId)) {
+        if ((moimRepository.findMoimByIdOrThrow(moimId).getHost().getUser())
+                .equals(guestRepository.findGuestByIdOrThrow(guestId).getUser().getId())) {
+            return true;
+        } else if (moimSubmissionRepository.existsByMoimIdAndGuestId(moimId, guestId)) {
             MoimSubmission moimSubmission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
 
             // 참가한 상태일 경우(승인된 상태 - approved , completed


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #210 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 커스텀 어노테이션 스웨거 반영과정에서 순서가 변동되며 500에러가 발생하여 순서를 다시 바꿔줬습니다.
- 생각해보니까 모임의 host일 경우 모든 공지를 확인할 수있어야한다고 생각해서 로직 구현햇습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-09-17 오전 12 36 03" src="https://github.com/user-attachments/assets/5bf05dcb-1461-4133-8d78-de18c3e72505">
