### PR TITLE
[fix] 프로필 수정 시 닉네임 중복검사 로직 변경 

### DIFF
--- a/src/main/java/com/pickple/server/api/guest/service/GuestCommandService.java
+++ b/src/main/java/com/pickple/server/api/guest/service/GuestCommandService.java
@@ -29,7 +29,7 @@ public class GuestCommandService {
 
     public void isDuplicatedNickname(String nickname) {
         if (hostRepository.existsByNickname(nickname) || guestRepository.existsByNickname(nickname) ||
-                submitterRepository.existsByNickname(nickname)) {
+                submitterRepository.existsByNicknameAndSubmitterState(nickname, "pending")) {
             throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
         }
     }

--- a/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostCommandService.java
@@ -23,9 +23,10 @@ public class HostCommandService {
 
     public void updateHostProfile(Long hostId, HostUpdateRequest hostUpdateRequest) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
-        if (!host.getNickname().equals(hostUpdateRequest.nickname()) && (hostRepository.existsByNickname(
-                hostUpdateRequest.nickname()) || guestRepository.existsByNickname(
-                hostUpdateRequest.nickname()) || submitterRepository.existsByNickname(hostUpdateRequest.nickname()))) {
+        if (!host.getNickname().equals(hostUpdateRequest.nickname())
+                && (hostRepository.existsByNickname(hostUpdateRequest.nickname())
+                || guestRepository.existsByNickname(hostUpdateRequest.nickname())
+                || submitterRepository.existsByNicknameAndSubmitterState(hostUpdateRequest.nickname(), "pending"))) {
             throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
         }
 

--- a/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
+++ b/src/main/java/com/pickple/server/api/submitter/repository/SubmitterRepository.java
@@ -18,6 +18,5 @@ public interface SubmitterRepository extends JpaRepository<Submitter, Long> {
                 .orElseThrow(() -> new CustomException(ErrorCode.SUBMITTER_NOT_FOUND));
     }
 
-    boolean existsByNickname(String nickname);
-
+    boolean existsByNicknameAndSubmitterState(String nickname, String submitterState);
 }

--- a/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
+++ b/src/main/java/com/pickple/server/api/submitter/service/SubmitterCommandService.java
@@ -73,7 +73,7 @@ public class SubmitterCommandService {
     private void isDuplicatedNickname(String nickname) {
         if (hostRepository.existsByNickname(nickname)) {
             throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
-        } else if (submitterRepository.existsByNickname(nickname)) {
+        } else if (submitterRepository.existsByNicknameAndSubmitterState(nickname, "pending")) {
             throw new CustomException(ErrorCode.DUPLICATION_NICKNAME);
         }
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #214 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 프로필 수정 시 닉네임 중복검사 로직을 변경했습니다.
    - 기존에는 호스트 승인신청한 이력이있는 모든 닉네임을 검사했지만 pending 상태만 검증하여 사용했던 닉네임도 사용할  수 있도록처리했습니다.
 - 호스트 게스트 모두 수정하였습니다

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
호스트 프로필 수정 api와 호스트 정보 조회 api 충돌을 막기 위해 hostId를 path로 받았는데 path로 입력받은 hostId와 어노테이션으로 얻은 @hostId를 비교 검증하는 과정을 추가했으면 좋겠습니다! 예린님 담당 api라서 need to refactor 붙여두겠습니다

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 호스트 수정
<img width="1470" alt="스크린샷 2024-09-17 오후 10 33 26" src="https://github.com/user-attachments/assets/8a5812d7-0a0b-4649-8e6b-7eb25032c4fa">
<img width="1470" alt="스크린샷 2024-09-17 오후 10 33 42" src="https://github.com/user-attachments/assets/2fe7b633-911c-4018-80e7-fb99a9d51b4c">

- 게스트 수정
<img width="1470" alt="스크린샷 2024-09-17 오후 10 36 24" src="https://github.com/user-attachments/assets/83e210a5-976d-4e15-9890-c509f3ba1882">
<img width="1470" alt="스크린샷 2024-09-17 오후 10 37 08" src="https://github.com/user-attachments/assets/7f35325c-ed15-41dd-aa4a-db5558e9b50f">

