### PR TITLE
[feat] 댓글 관련 베테랑 스티커를 위한 response 추가

### DIFF
--- a/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/com/pickple/server/api/comment/dto/response/CommentGetResponse.java
@@ -15,6 +15,9 @@ public record CommentGetResponse(
 
         String commentContent,
 
-        String commentDate
+        String commentDate,
+
+        boolean isVeteran
+
 ) {
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #226 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 댓글 관련 베테랑 스티커를 위한 response 배테랑 여부를 추가했습니다
   - isOwner가 true일 경우 완료한 모임의 수를 파악하여 반환해줬습니다
   - isOwner가 flase일 경우 베테랑 스티커가 필요하지 않다고 생각해서 바로 flase를 반환했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
베테랑 여부를 판단하는 부분이 총 4부분이라서 예린씨 돌아오면 상의 후 host 테이블에 컬럼으로 추가하고싶슴다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="스크린샷 2024-09-18 오후 11 09 36" src="https://github.com/user-attachments/assets/e79d931b-66bd-4f02-81f2-f2edffc7adb0">

