### PR TITLE
[fix] 모임 상태와 isOngoing 필드값 동기화되도록 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -16,7 +16,6 @@ import com.pickple.server.api.review.repository.ReviewRepository;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import com.pickple.server.global.util.DateTimeUtil;
-import com.pickple.server.global.util.DateUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -194,7 +193,6 @@ public class MoimSubmissionQueryService {
 
     public boolean isOngoing(Long moimId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
-        int day = DateUtil.calculateCompletedDay(moim.getDateList().getDate());
-        return day >= 0;
+        return moim.getMoimState().equals("ongoing");
     }
 }

--- a/src/main/java/com/pickple/server/global/util/DateUtil.java
+++ b/src/main/java/com/pickple/server/global/util/DateUtil.java
@@ -12,12 +12,6 @@ public class DateUtil {
         return dday;
     }
 
-    public static int calculateCompletedDay(LocalDate date) {
-        LocalDate today = LocalDate.now();
-        int day = (int) ChronoUnit.DAYS.between(today, date);
-        return day;
-    }
-
     public static String refineDate(LocalDate localDate) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         return localDate.format(formatter);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #232 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 상태와 isOngoing 필드값 동기화되도록 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 스케줄러가 도입되어 해당 필드값은 이제 불필요하나, 클라에서 해당 값을 사용하는 코드가 많다고 하여 일단은 두고 추후 스프린트 때 제거하는 방향으로 논의했습니다.
- need to refactor 달아놓겠습니다!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1382" alt="스크린샷 2024-09-21 오전 1 02 01" src="https://github.com/user-attachments/assets/af6a02a7-ea39-4d35-b190-47cce628fdd1">

