### PR TITLE
[feat] 호스트 승인 시 토큰 만료되도록 구현 

### DIFF
--- a/src/main/java/com/pickple/server/api/user/service/UserService.java
+++ b/src/main/java/com/pickple/server/api/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.pickple.server.api.user.service;
 
+import static com.pickple.server.global.auth.jwt.provider.JwtValidationType.EXPIRED_JWT_TOKEN;
+
 import com.pickple.server.api.guest.domain.Guest;
 import com.pickple.server.api.guest.repository.GuestRepository;
 import com.pickple.server.api.host.domain.Host;
@@ -98,6 +100,11 @@ public class UserService {
     public AccessTokenGetSuccess refreshToken(
             final String refreshToken
     ) {
+        if (jwtTokenProvider.validateToken(refreshToken) == EXPIRED_JWT_TOKEN) {
+            // 리프레시 토큰이 만료된 경우
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
         Long userId = jwtTokenProvider.getUserFromJwt(refreshToken);
         if (!userId.equals(tokenService.findIdByRefreshToken(refreshToken))) {
             throw new CustomException(ErrorCode.TOKEN_INCORRECT_ERROR);

--- a/src/main/java/com/pickple/server/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pickple/server/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,9 +1,14 @@
 package com.pickple.server.global.auth.jwt.filter;
 
+import static com.pickple.server.global.auth.jwt.provider.JwtValidationType.EXPIRED_JWT_TOKEN;
 import static com.pickple.server.global.auth.jwt.provider.JwtValidationType.VALID_JWT;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickple.server.global.auth.jwt.provider.JwtTokenProvider;
 import com.pickple.server.global.auth.security.UserAuthentication;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.ApiResponseDto;
+import com.pickple.server.global.response.enums.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         try {
             final String token = getJwtFromRequest(request);
+
             if (token != null && jwtTokenProvider.validateToken(token) == VALID_JWT) {
                 Long memberId = jwtTokenProvider.getUserFromJwt(token);
 
@@ -44,18 +50,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, authorities);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else if (jwtTokenProvider.validateToken(token) == EXPIRED_JWT_TOKEN) {
+                // 토큰이 만료된 경우 CustomException 던짐
+                throw new CustomException(ErrorCode.ACCESS_TOKEN_EXPIRED);
             }
-        } catch (Exception exception) {
-            try {
-                throw new Exception();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+
+            // 다음 필터로 요청 전달
+            filterChain.doFilter(request, response);
+
+        } catch (CustomException e) {
+            // CustomException을 잡아서 클라이언트에게 응답
+            handleException(response, e.getErrorCode());
         }
-        // 다음 필터로 요청 전달
-        filterChain.doFilter(request, response);
     }
 
+    // 예외 처리 및 응답
+    private void handleException(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        // ObjectMapper는 예외 처리시에만 생성하여 메모리 최적화
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // 실패 응답 생성
+        ApiResponseDto<?> apiResponse = ApiResponseDto.fail(errorCode);
+
+        // 응답을 JSON 형식으로 변환 후 출력
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+
+    // JWT를 요청 헤더에서 추출
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -23,11 +23,11 @@ public enum ErrorCode {
     NO_SUBMISSION_FOUND_FOR_REVIEW(40011, HttpStatus.BAD_REQUEST, "리뷰를 작성할 수 있는 신청이 없습니다"),
     NOT_AUTHOR(40012, HttpStatus.BAD_REQUEST, "해당 댓글의 작성자가 아닙니다."),
     DUPLICATION_APPROVE_SUBMITTER(40013, HttpStatus.BAD_REQUEST, "이미 호스트입니다."),
-    
+
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),    //code 건들지 말것, 클라 분기처리함
     TOKEN_INCORRECT_ERROR(40101, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),    //code 건들지 말것, 클라 분기처리함
-    EMPTY_PRINCIPAL(40103, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EMPTY_PRINCIPAL(40102, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     //403 Forbidden
     NOT_ADMIN(40301, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -26,8 +26,9 @@ public enum ErrorCode {
 
     // 401 Unauthorized
     ACCESS_TOKEN_EXPIRED(40100, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),    //code 건들지 말것, 클라 분기처리함
-    TOKEN_INCORRECT_ERROR(40101, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),    //code 건들지 말것, 클라 분기처리함
-    EMPTY_PRINCIPAL(40102, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(40101, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),    //code 건들지 말것, 클라 분기처리함
+    TOKEN_INCORRECT_ERROR(40102, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+    EMPTY_PRINCIPAL(40103, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     //403 Forbidden
     NOT_ADMIN(40301, HttpStatus.UNAUTHORIZED, "관리자 계정이 아닙니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #236 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 토큰이 만료됐을 경우 에러메세지를 발생시켰습니다
   - 엑세스 토큰 만료 >> 40100 >> 클라가 해당 에러 발생 시 리프레시 토큰 재발급 api로 연결
   - 리프레시 토큰 만료 >> 40101 >> 클라가 해당 에러 발생 시  재로그인으로 연결

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 호스트 승인 시 리프레시토큰을 만료시켜서 재로그인으로 연결시키려고 했는데 그래도 엑세스 토큰이 살아있는 동안 이슈가 발생한다고 판단하였습니다.
- 클라와의 논의를 통해 클라측에서 로그인시 HostId와 마이페이지 스픽커 클릭시 요청되는 api의 hostId와 비교하여 한번 더 처리하기로 했습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1034" alt="스크린샷 2024-09-25 오전 12 28 12" src="https://github.com/user-attachments/assets/b20f3ffb-c4e0-4f3f-a3f5-98e9b6f26ebe">
<img width="1470" alt="스크린샷 2024-09-25 오전 12 58 39" src="https://github.com/user-attachments/assets/bbd750cb-f62b-48ac-959f-f9a5a5cfef70">

