### PR TITLE
[fix] 모임에 해당하는 신청자 전체 조회 api 및 에러 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
+++ b/src/main/java/com/pickple/server/api/host/service/HostQueryService.java
@@ -71,7 +71,7 @@ public class HostQueryService {
                 .map(Moim::getId) // Moim 엔티티에서 id를 추출
                 .collect(Collectors.toList());
 
-        return moimSubmissionRepository.countApprovedSubmissionsByMoimIds(moimIds);
+        return moimSubmissionRepository.countCompletedSubmissionsByMoimIds(moimIds);
     }
 
     private boolean checkVeteran(Long hostId) {

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -31,7 +31,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     List<MoimSubmission> findMoimListByMoimId(Long moimId);
 
-    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected')")
+    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected','completed')")
     List<MoimSubmission> findMoimListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -27,9 +27,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     MoimSubmission findByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<MoimSubmission> findBymoimId(Long moimId);
-
-    List<MoimSubmission> findMoimListByMoimId(Long moimId);
+    List<MoimSubmission> findMoimSubmissionByMoimId(Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected','completed')")
     List<MoimSubmission> findMoimListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -35,7 +35,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
 
-    @Query(value = "SELECT COUNT(*) FROM moim_submissions WHERE moim_id = :moimId AND moim_submission_state = 'approved'", nativeQuery = true)
+    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState = 'approved'")
     long countApprovedMoimSubmissions(@Param("moimId") Long moimId);
 
     @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'approved'")

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -38,8 +38,8 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState = 'approved'")
     long countApprovedMoimSubmissions(@Param("moimId") Long moimId);
 
-    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'approved'")
-    int countApprovedSubmissionsByMoimIds(@Param("moimIds") List<Long> moimIds);
+    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'completed'")
+    int countCompletedSubmissionsByMoimIds(@Param("moimIds") List<Long> moimIds);
 
     boolean existsByMoimIdAndGuestIdAndMoimSubmissionState(Long moimId, Long guestId, String MoimSubmissionState);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -42,7 +42,7 @@ public class MoimSubmissionCommandService {
     }
 
     public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findBymoimId(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByMoimId(moimId);
 
         for (MoimSubmission moimSubmission : moimSubmissionList) {
             if (submitterIdList.contains(moimSubmission.getGuestId())) {

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -178,8 +178,7 @@ public class MoimSubmissionQueryService {
     }
 
     public boolean isMoimSubmissonApproved(Long moimId) {
-        Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimId(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByMoimId(moimId);
 
         //모임에 해당하는 신청 내역 중 approved or rejected가 있는 경우 true 리턴
         for (MoimSubmission moimSubmission : moimSubmissionList) {

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -97,8 +97,8 @@ public class MoimSubmissionQueryService {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
 
         // moimSubmissionList 가져오기
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimListByMoimIdAndMoimSubmissionState(
-                moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository
+                .findMoimListByMoimIdAndMoimSubmissionState(moimId);
 
         // guestId를 이용하여 SubmitterInfo 객체 생성 후 리스트에 저장
         List<SubmitterInfo> submitterInfoList = moimSubmissionList.stream()


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #243 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
각종 에러를 수정했습니다
1. 모임에 해당하는 신청자 전체 조회 api의 에러를 수정했습닌다.
   ![image](https://github.com/user-attachments/assets/4fe253ad-c96d-46ee-b4e3-cacc8de3c442)
   - 해당 api가 완료된 모임일 경우에도 사용되는 api이기 때문에 completed도 함께 검색되도록 수정하였습니다.
      어차피 모임 완료 전엔 completed가 없어서 문제가 되지 않을것같은데 어떻게 생각하시나요?
   - isMoimSubmissionApproved가 잘못내려가고 있어서 모집 전에도 승인이 가능했습니다.
      메소드명이 잘못되어있어서 통합 및 수정을 진행하였습니다.
   
2. 아래 뷰에서 승인된 게스트의 인원수가 조회되지않아서 nativeQuery를 JPQL로 수정하였습니다. [관련 커밋](https://github.com/PICK-PLE/PICKPLE-server/commit/fb095237dc1a960316bea8bdb95179f183aea458)
    <img width="411" alt="image" src="https://github.com/user-attachments/assets/08bc31d3-b5da-44d5-b383-7eadea88d8b2">


3. 아래 뷰에서 승인된 참가자가 아닌 완료된 참가자가 조회되도록 수정하였습니다 [관련 커밋](https://github.com/PICK-PLE/PICKPLE-server/commit/8926e2d96abf3a8fb79b50a4925ab7013382144e)
  <img width="405" alt="image" src="https://github.com/user-attachments/assets/9565a075-ba6d-42eb-ba9f-a8d5ef7299e4">


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
개발환경에서 확인해보는것이 빠를 것 같아서 선 머지 후 확인하겠습니다!