### PR TITLE
[fix] 모임 승인 가능 여부 판단 로직 수정 및 승인 인원 count 로직 수정

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -137,7 +137,7 @@ public class MoimQueryService {
 
     private Long calculateApprovedGuest(Long moimId) {
         try {
-            return moimSubmissionRepository.countApprovedMoimSubmissions(moimId);
+            return moimSubmissionRepository.countValidMoimSubmissions(moimId);
         } catch (InvalidDataAccessResourceUsageException e) {
             // 테이블이 존재하지 않아서 발생한 예외일 경우 0 반환
             return 0L;

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -35,8 +35,8 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
 
-    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState = 'approved'")
-    long countApprovedMoimSubmissions(@Param("moimId") Long moimId);
+    @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN('approved','completed')")
+    long countValidMoimSubmissions(@Param("moimId") Long moimId);
 
     @Query("SELECT COUNT(ms) FROM MoimSubmission ms WHERE ms.moim.id IN :moimIds AND ms.moimSubmissionState = 'completed'")
     int countCompletedSubmissionsByMoimIds(@Param("moimIds") List<Long> moimIds);

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -144,19 +144,24 @@ public class MoimSubmissionQueryService {
                 .build();
     }
 
-
     private boolean isApprovable(Moim moim) {
         // 모임일
         LocalDate date = moim.getDateList().getDate();
 
-        // 마감일: 신청일 + 3일의 자정
-        LocalDateTime deadline = date.minusDays(3).atTime(LocalTime.MIDNIGHT);
+        // 모임 시작 시간
+        LocalTime startTime = moim.getDateList().getStartTime();
+
+        // 승인 가능 시작 시간: 모임일 전날 자정 (모임일 하루 전 자정)
+        LocalDateTime approvalStartTime = date.minusDays(1).atStartOfDay();
+
+        // 승인 가능 종료 시간: 모임일의 시작 시간
+        LocalDateTime approvalEndTime = date.atTime(startTime);
 
         // 현재 시간
         LocalDateTime now = LocalDateTime.now();
 
-        // 승인 가능 여부: 현재 시간이 마감일 이후인지 확인
-        return now.isAfter(deadline);
+        // 승인 가능 여부: 현재 시간이 승인 시작 시간 이후 또는 같은 시간이고, 승인 종료 시간 이전인지 확인
+        return (now.isEqual(approvalStartTime) || now.isAfter(approvalStartTime)) && now.isBefore(approvalEndTime);
     }
 
     public SubmitterInfo getSubmitterInfo(Long guestId, Long moimId) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #245

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 승인 가능 여부 판단 로직 수정하였습니다
   <img width="649" alt="image" src="https://github.com/user-attachments/assets/4b538c82-1e59-4f55-a205-b8581374e52c">
    해당 요구사항을 반영하여 로직을 수정하였습니다.
   승인 시작 시간: date.minusDays(1).atStartOfDay()로 설정하여, 모임일 하루 전 자정부터 승인 가능하도록 했습니다.
    승인 종료 시간: date.atTime(startTime)으로 설정하여, 모임 시작 시간 전까지 승인 가능하도록 했습니다.
    승인 조건:
    - now.isEqual(approvalStartTime) || now.isAfter(approvalStartTime): 현재 시간이 승인 시작 시간과 같거나 그 이후여야 합니다.
    - now.isBefore(approvalEndTime): 현재 시간이 승인 종료 시간 이전이어야 합니다.

-  승인 인원 count 로직 수정
   - 앞선 pr과 같이 진행중인모임과 완료된 모임에서 같은 api를 쓰고있어서 승인과 완료된 모임을 함께 계산하도록 하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
진행중인 모임과 완료된 모임관련 api를 분리해야할지 고민됩니다. 근데 사실 로직 상 카운팅될 때 두 상태가 혼용될 일은 없다고 생각되는데 어떻게 생각하시는지요..!

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->