### PR TITLE
[hotfix] 모임 종료 시 모임 참여 신청 상태값 completed로 변경

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -51,7 +51,7 @@ public class MoimCommandService {
     }
 
     //정각마다 실행
-    @Scheduled(cron = "0 48 0/1 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
         String formattedDate = DateUtil.refineDate(date);

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -7,6 +7,8 @@ import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.dto.request.MoimCreateRequest;
 import com.pickple.server.api.moim.dto.response.MoimCreateResponse;
 import com.pickple.server.api.moim.repository.MoimRepository;
+import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
+import com.pickple.server.api.moimsubmission.repository.MoimSubmissionRepository;
 import com.pickple.server.global.util.DateUtil;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -23,6 +25,7 @@ public class MoimCommandService {
 
     private final HostRepository hostRepository;
     private final MoimRepository moimRepository;
+    private final MoimSubmissionRepository moimSubmissionRepository;
 
     public MoimCreateResponse createMoim(Long hostId, MoimCreateRequest request) {
         Host host = hostRepository.findHostByIdOrThrow(hostId);
@@ -48,7 +51,7 @@ public class MoimCommandService {
     }
 
     //정각마다 실행
-    @Scheduled(cron = "0 0 0/1 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 48 0/1 * * *", zone = "Asia/Seoul")
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
         String formattedDate = DateUtil.refineDate(date);
@@ -57,6 +60,11 @@ public class MoimCommandService {
         for (Moim moim : moimList) {
             if (moim.getDateList().getEndTime().isBefore(LocalTime.now())) {
                 moim.updateMoimState("completed");
+                List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findApprovedMoimSubmissionsByMoimId(
+                        moim.getId());
+                for (MoimSubmission moimSubmission : moimSubmissionList) {
+                    moimSubmission.updateMoimSubmissionState("completed");
+                }
             }
         }
     }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -46,4 +46,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
     List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
 
+    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moimSubmissionState = 'approved'")
+    List<MoimSubmission> findAllApprovedMoimSubmissions();
+
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -46,7 +46,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
     List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
 
-    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moimSubmissionState = 'approved'")
-    List<MoimSubmission> findAllApprovedMoimSubmissions();
+    @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState = 'approved'")
+    List<MoimSubmission> findApprovedMoimSubmissionsByMoimId(@Param("moimId") Long moimId);
 
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -1,7 +1,6 @@
 package com.pickple.server.api.moimsubmission.service;
 
 import com.pickple.server.api.moim.domain.Moim;
-import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
@@ -11,7 +10,6 @@ import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,16 +70,6 @@ public class MoimSubmissionCommandService {
             moimSubmission.updateMoimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState());
         } else {
             throw new CustomException(ErrorCode.MOIM_SUBMISSION_STATE_TRANSITION_NOT_ALLOWED);
-        }
-    }
-
-    @Scheduled(cron = "0 1 0/1 * * *", zone = "Asia/Seoul")
-    public void changeMoimSubmissionStateOfEndTime() {
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllApprovedMoimSubmissions();
-        for (MoimSubmission moimSubmission : moimSubmissionList) {
-            if (moimSubmission.getMoim().getMoimState().equals(MoimState.COMPLETED.getMoimState())) {
-                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.COMPLETED.getMoimSubmissionState());
-            }
         }
     }
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -1,6 +1,7 @@
 package com.pickple.server.api.moimsubmission.service;
 
 import com.pickple.server.api.moim.domain.Moim;
+import com.pickple.server.api.moim.domain.enums.MoimState;
 import com.pickple.server.api.moim.repository.MoimRepository;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmissionState;
@@ -10,6 +11,7 @@ import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,6 +72,16 @@ public class MoimSubmissionCommandService {
             moimSubmission.updateMoimSubmissionState(MoimSubmissionState.PENDING_APPROVAL.getMoimSubmissionState());
         } else {
             throw new CustomException(ErrorCode.MOIM_SUBMISSION_STATE_TRANSITION_NOT_ALLOWED);
+        }
+    }
+
+    @Scheduled(cron = "0 1 0/1 * * *", zone = "Asia/Seoul")
+    public void changeMoimSubmissionStateOfEndTime() {
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findAllApprovedMoimSubmissions();
+        for (MoimSubmission moimSubmission : moimSubmissionList) {
+            if (moimSubmission.getMoim().getMoimState().equals(MoimState.COMPLETED.getMoimState())) {
+                moimSubmission.updateMoimSubmissionState(MoimSubmissionState.COMPLETED.getMoimSubmissionState());
+            }
         }
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #247 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 모임 종료 시 해당 모임의 신청 상태값을 전부 completed로 변경
  - 스케줄러를 활용하여 매 시 1분마다 approved인 moimSubmission들의 리스트를 가져와 해당 모임의 상태값이 completed인 경우 상태를 업데이트 하도록 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 1분으로 한 이유는 정각에 모임의 진행 상태값이 바뀌기 때문에 혹시 모를 이슈를 방지하기 위해 1분에 돌아가도록 만들었습니다.

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1440" alt="스크린샷 2024-10-14 오후 11 01 10" src="https://github.com/user-attachments/assets/9daeb8a0-e4b2-4ea8-babc-abd23859e698">
