### PR TITLE
[fix] 리뷰 조회 api 정렬 추가 및 repository 메소드명 컨벤션 적용

### DIFF
--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -17,21 +17,21 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_NOT_FOUND));
     }
 
-    List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
+    List<Moim> findMoimsByhostIdAndMoimState(Long hostId, String moimState);
 
     @Query(value = "SELECT * FROM moims WHERE EXISTS (" +
             "SELECT 1 FROM jsonb_each_text(category_list) AS categories " +
             "WHERE categories.value = :category)",
             nativeQuery = true)
-    List<Moim> findMoimListByCategory(@Param("category") String category);
+    List<Moim> findMoimsByCategory(@Param("category") String category);
 
     @Query(value = "SELECT * FROM moims WHERE date_list->>'date' = :date AND moim_state = 'ongoing'", nativeQuery = true)
-    List<Moim> findByDate(String date);
+    List<Moim> findMoimsByDate(String date);
 
     @Query("SELECT m FROM Moim m WHERE m.host.id = :hostId AND m.moimState = 'completed'")
     List<Moim> findCompletedMoimsByHostId(@Param("hostId") Long hostId);
 
-    List<Moim> findMoimByHostId(Long hostId);
+    List<Moim> findMoimsByHostId(Long hostId);
 
     int countByHostIdAndMoimState(Long hostId, String moimState);
 }

--- a/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
+++ b/src/main/java/com/pickple/server/api/moim/repository/MoimRepository.java
@@ -17,8 +17,6 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_NOT_FOUND));
     }
 
-    int countByHostId(Long hostId);
-
     List<Moim> findMoimByhostIdAndMoimState(Long hostId, String moimState);
 
     @Query(value = "SELECT * FROM moims WHERE EXISTS (" +

--- a/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimCommandService.java
@@ -52,7 +52,7 @@ public class MoimCommandService {
     public void changeMoimStateOfDday() {
         LocalDate date = LocalDate.now();
         String formattedDate = DateUtil.refineDate(date);
-        List<Moim> moimList = moimRepository.findByDate(formattedDate);
+        List<Moim> moimList = moimRepository.findMoimsByDate(formattedDate);
 
         for (Moim moim : moimList) {
             if (moim.getDateList().getEndTime().isBefore(LocalTime.now())) {

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -67,7 +67,7 @@ public class MoimQueryService {
         if (category.equals("all")) {
             moimList = moimRepository.findAll();
         } else {
-            moimList = moimRepository.findMoimListByCategory(category);
+            moimList = moimRepository.findMoimsByCategory(category);
         }
 
         return moimList.stream()
@@ -106,7 +106,7 @@ public class MoimQueryService {
     }
 
     public List<MoimListByHostAndMoimStateGetResponse> getMoimListByHostAndMoimState(Long hostId, String moimState) {
-        List<Moim> moimList = moimRepository.findMoimByhostIdAndMoimState(hostId, moimState);
+        List<Moim> moimList = moimRepository.findMoimsByhostIdAndMoimState(hostId, moimState);
 
         return moimList.stream()
                 .map(oneMoim -> MoimListByHostAndMoimStateGetResponse.builder()
@@ -120,7 +120,7 @@ public class MoimQueryService {
     }
 
     public List<MoimListByHostGetResponse> getMoimListByHost(Long hostId) {
-        List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
+        List<Moim> moimList = moimRepository.findMoimsByHostId(hostId);
 
         return moimList.stream()
                 .map(oneMoim -> MoimListByHostGetResponse.builder()

--- a/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
+++ b/src/main/java/com/pickple/server/api/moim/service/MoimQueryService.java
@@ -43,7 +43,7 @@ public class MoimQueryService {
                 .fee(moim.getFee())
                 .imageList(moim.getImageList())
                 .hostId(moim.getHost().getId())
-                .isSubmitted(moimSubmissionRepository.existsByMoimAndGuestId(moim, guestId))
+                .isSubmitted(moimSubmissionRepository.existsByMoimIdAndGuestId(moimId, guestId))
                 .build();
     }
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -1,6 +1,5 @@
 package com.pickple.server.api.moimsubmission.repository;
 
-import com.pickple.server.api.moim.domain.Moim;
 import com.pickple.server.api.moimsubmission.domain.MoimSubmission;
 import com.pickple.server.global.exception.CustomException;
 import com.pickple.server.global.response.enums.ErrorCode;
@@ -18,8 +17,6 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
         return findMoimSubmissionById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND));
     }
-
-    boolean existsByMoimAndGuestId(Moim moim, Long guestId);
 
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -20,14 +20,14 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<MoimSubmission> findMoimSubmissionByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
+    List<MoimSubmission> findMoimSubmissionsByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
 
     MoimSubmission findByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<MoimSubmission> findMoimSubmissionByMoimId(Long moimId);
+    List<MoimSubmission> findMoimSubmissionsByMoimId(Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected','completed')")
-    List<MoimSubmission> findMoimSubmissionListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
+    List<MoimSubmission> findMoimSubmissionsByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
@@ -41,5 +41,5 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     boolean existsByMoimIdAndGuestIdAndMoimSubmissionState(Long moimId, Long guestId, String MoimSubmissionState);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
-    List<MoimSubmission> findSubmittedMoimSubmissionList(@Param("guestId") Long guestId);
+    List<MoimSubmission> findSubmittedMoimSubmissions(@Param("guestId") Long guestId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -20,14 +20,14 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<MoimSubmission> findAllByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
+    List<MoimSubmission> findMoimSubmissionByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
 
     MoimSubmission findByMoimIdAndGuestId(Long moimId, Long guestId);
 
     List<MoimSubmission> findMoimSubmissionByMoimId(Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.moim.id = :moimId AND ms.moimSubmissionState IN ('pendingApproval', 'approved', 'rejected','completed')")
-    List<MoimSubmission> findMoimListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
+    List<MoimSubmission> findMoimSubmissionListByMoimIdAndMoimSubmissionState(@Param("moimId") Long moimId);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState = 'completed'")
     List<MoimSubmission> findCompletedMoimSubmissionsByGuest(@Param("guestId") Long guestId);
@@ -41,5 +41,5 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
     boolean existsByMoimIdAndGuestIdAndMoimSubmissionState(Long moimId, Long guestId, String MoimSubmissionState);
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
-    List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
+    List<MoimSubmission> findSubmittedMoimSubmissionList(@Param("guestId") Long guestId);
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -22,7 +22,7 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     List<MoimSubmission> findMoimSubmissionsByGuestIdAndMoimSubmissionState(Long guestId, String moimSubmissionState);
 
-    MoimSubmission findByMoimIdAndGuestId(Long moimId, Long guestId);
+    MoimSubmission findMoimSubmissionByMoimIdAndGuestId(Long moimId, Long guestId);
 
     List<MoimSubmission> findMoimSubmissionsByMoimId(Long moimId);
 

--- a/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/repository/MoimSubmissionRepository.java
@@ -45,5 +45,4 @@ public interface MoimSubmissionRepository extends JpaRepository<MoimSubmission, 
 
     @Query("SELECT ms FROM MoimSubmission ms WHERE ms.guestId = :guestId AND ms.moimSubmissionState IN ('pendingPayment','pendingApproval', 'approved', 'rejected','refunded')")
     List<MoimSubmission> findAllSubmittedMoimSubmission(@Param("guestId") Long guestId);
-
 }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -30,13 +30,13 @@ public class MoimSubmissionCommandService {
                 .accountList(request.accountList())
                 .moimSubmissionState(MoimSubmissionState.PENDING_PAYMENT.getMoimSubmissionState())
                 .build();
-        isDuplicatedMoimSubmission(moimSubmission);
+        isDuplicatedMoimSubmission(moimId, guestId);
         moimSubmissionRepository.save(moimSubmission);
     }
 
-    private void isDuplicatedMoimSubmission(MoimSubmission moimSubmission) {
-        if (moimSubmissionRepository.existsByMoimAndGuestId(moimSubmission.getMoim(),
-                moimSubmission.getGuestId())) {
+    private void isDuplicatedMoimSubmission(Long moimId, Long guestId) {
+        if (moimSubmissionRepository.existsByMoimIdAndGuestId(moimId,
+                guestId)) {
             throw new CustomException(ErrorCode.DUPLICATION_MOIM_SUBMISSION);
         }
     }

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionCommandService.java
@@ -42,7 +42,7 @@ public class MoimSubmissionCommandService {
     }
 
     public void updateSubmissionState(Long moimId, List<Long> submitterIdList) {
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByMoimId(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionsByMoimId(moimId);
 
         for (MoimSubmission moimSubmission : moimSubmissionList) {
             if (submitterIdList.contains(moimSubmission.getGuestId())) {

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -61,7 +61,7 @@ public class MoimSubmissionQueryService {
     }
 
     public SubmittionDetailResponse getSubmissionDetail(Long moimId, Long guestId) {
-        MoimSubmission submission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
+        MoimSubmission submission = moimSubmissionRepository.findMoimSubmissionByMoimIdAndGuestId(moimId, guestId);
 
         if (submission == null) {
             throw new CustomException(ErrorCode.MOIM_SUBMISSION_NOT_FOUND);
@@ -170,7 +170,7 @@ public class MoimSubmissionQueryService {
                 .orElseThrow(() -> new CustomException(ErrorCode.GUEST_NOT_FOUND));
 
         //MoimSubmission 객체를 가져옴
-        MoimSubmission moimSubmission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
+        MoimSubmission moimSubmission = moimSubmissionRepository.findMoimSubmissionByMoimIdAndGuestId(moimId, guestId);
 
         // SubmitterInfo 객체 생성
         return new SubmitterInfo(

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -41,10 +41,10 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList;
 
         if (moimSubmissionState.equals(MoimSubmissionState.ALL.getMoimSubmissionState())) {
-            moimSubmissionList = moimSubmissionRepository.findAllSubmittedMoimSubmission(guest.getId());
+            moimSubmissionList = moimSubmissionRepository.findSubmittedMoimSubmissionList(guest.getId());
         } else {
-            moimSubmissionList = moimSubmissionRepository.findAllByGuestIdAndMoimSubmissionState(guestId,
-                    moimSubmissionState);
+            moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByGuestIdAndMoimSubmissionState
+                    (guestId, moimSubmissionState);
         }
 
         return moimSubmissionList.stream()
@@ -98,7 +98,7 @@ public class MoimSubmissionQueryService {
 
         // moimSubmissionList 가져오기
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository
-                .findMoimListByMoimIdAndMoimSubmissionState(moimId);
+                .findMoimSubmissionListByMoimIdAndMoimSubmissionState(moimId);
 
         // guestId를 이용하여 SubmitterInfo 객체 생성 후 리스트에 저장
         List<SubmitterInfo> submitterInfoList = moimSubmissionList.stream()

--- a/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
+++ b/src/main/java/com/pickple/server/api/moimsubmission/service/MoimSubmissionQueryService.java
@@ -41,9 +41,9 @@ public class MoimSubmissionQueryService {
         List<MoimSubmission> moimSubmissionList;
 
         if (moimSubmissionState.equals(MoimSubmissionState.ALL.getMoimSubmissionState())) {
-            moimSubmissionList = moimSubmissionRepository.findSubmittedMoimSubmissionList(guest.getId());
+            moimSubmissionList = moimSubmissionRepository.findSubmittedMoimSubmissions(guest.getId());
         } else {
-            moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByGuestIdAndMoimSubmissionState
+            moimSubmissionList = moimSubmissionRepository.findMoimSubmissionsByGuestIdAndMoimSubmissionState
                     (guestId, moimSubmissionState);
         }
 
@@ -98,7 +98,7 @@ public class MoimSubmissionQueryService {
 
         // moimSubmissionList 가져오기
         List<MoimSubmission> moimSubmissionList = moimSubmissionRepository
-                .findMoimSubmissionListByMoimIdAndMoimSubmissionState(moimId);
+                .findMoimSubmissionsByMoimIdAndMoimSubmissionState(moimId);
 
         // guestId를 이용하여 SubmitterInfo 객체 생성 후 리스트에 저장
         List<SubmitterInfo> submitterInfoList = moimSubmissionList.stream()
@@ -183,7 +183,7 @@ public class MoimSubmissionQueryService {
     }
 
     public boolean isMoimSubmissonApproved(Long moimId) {
-        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionByMoimId(moimId);
+        List<MoimSubmission> moimSubmissionList = moimSubmissionRepository.findMoimSubmissionsByMoimId(moimId);
 
         //모임에 해당하는 신청 내역 중 approved or rejected가 있는 경우 true 리턴
         for (MoimSubmission moimSubmission : moimSubmissionList) {

--- a/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/pickple/server/api/notice/repository/NoticeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    List<Notice> findNoticeByMoimIdOrderByCreatedAtDesc(Long moimId);
+    List<Notice> findNoticesByMoimIdOrderByCreatedAtDesc(Long moimId);
 
     Optional<Notice> findNoticeById(Long id);
 

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -31,7 +31,7 @@ public class NoticeQueryService {
 
     public List<NoticeListGetByMoimResponse> getNoticeListByMoimId(Long moimId, Long guestId) {
         Moim moim = moimRepository.findMoimByIdOrThrow(moimId);
-        List<Notice> noticeList = noticeRepository.findNoticeByMoimIdOrderByCreatedAtDesc(moimId);
+        List<Notice> noticeList = noticeRepository.findNoticesByMoimIdOrderByCreatedAtDesc(moimId);
 
         boolean isAppliedUser = isUserAppliedToMoim(moimId, guestId);
 

--- a/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
+++ b/src/main/java/com/pickple/server/api/notice/service/NoticeQueryService.java
@@ -79,7 +79,8 @@ public class NoticeQueryService {
                 .equals(guestRepository.findGuestByIdOrThrow(guestId).getUser())) {
             return true;
         } else if (moimSubmissionRepository.existsByMoimIdAndGuestId(moimId, guestId)) {
-            MoimSubmission moimSubmission = moimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId);
+            MoimSubmission moimSubmission = moimSubmissionRepository.findMoimSubmissionByMoimIdAndGuestId
+                    (moimId, guestId);
 
             // 참가한 상태일 경우(승인된 상태 - approved , completed
             return moimSubmission.getMoimSubmissionState()

--- a/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
+++ b/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
@@ -55,7 +55,7 @@ public class ReviewQueryService {
         List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
 
         return moimList.stream()
-                .flatMap(oneMoim -> reviewRepository.findReviewByMoimId(oneMoim.getId()).stream()
+                .flatMap(oneMoim -> reviewRepository.findReviewListByMoimIdOrderByCreatedAt(oneMoim.getId()).stream()
                         .map(review -> ReviewListGetByHostResponse.builder()
                                 .moimId(oneMoim.getId())
                                 .moimTitle(oneMoim.getTitle())

--- a/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
+++ b/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
@@ -37,7 +37,7 @@ public class ReviewQueryService {
     }
 
     public List<ReviewListGetByMoimResponse> getReviewListByMoim(Long moimId) {
-        List<Review> reviews = reviewRepository.findReviewListByMoimIdOrderByCreatedAt(moimId);
+        List<Review> reviews = reviewRepository.findReviewsByMoimIdOrderByCreatedAt(moimId);
 
         return reviews.stream()
                 .map(review -> ReviewListGetByMoimResponse.builder()
@@ -52,10 +52,10 @@ public class ReviewQueryService {
     }
 
     public List<ReviewListGetByHostResponse> getReviewListByHost(Long hostId) {
-        List<Moim> moimList = moimRepository.findMoimByHostId(hostId);
+        List<Moim> moimList = moimRepository.findMoimsByHostId(hostId);
 
         return moimList.stream()
-                .flatMap(oneMoim -> reviewRepository.findReviewListByMoimIdOrderByCreatedAt(oneMoim.getId()).stream()
+                .flatMap(oneMoim -> reviewRepository.findReviewsByMoimIdOrderByCreatedAt(oneMoim.getId()).stream()
                         .map(review -> ReviewListGetByHostResponse.builder()
                                 .moimId(oneMoim.getId())
                                 .moimTitle(oneMoim.getTitle())

--- a/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
+++ b/src/main/java/com/pickple/server/api/review/Service/ReviewQueryService.java
@@ -37,7 +37,7 @@ public class ReviewQueryService {
     }
 
     public List<ReviewListGetByMoimResponse> getReviewListByMoim(Long moimId) {
-        List<Review> reviews = reviewRepository.findReviewListByMoimId(moimId);
+        List<Review> reviews = reviewRepository.findReviewListByMoimIdOrderByCreatedAt(moimId);
 
         return reviews.stream()
                 .map(review -> ReviewListGetByMoimResponse.builder()

--- a/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
@@ -8,6 +8,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    List<Review> findReviewListByMoimIdOrderByCreatedAt(Long moimId);
+    List<Review> findReviewsByMoimIdOrderByCreatedAt(Long moimId);
 
 }

--- a/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
@@ -1,10 +1,20 @@
 package com.pickple.server.api.review.repository;
 
 import com.pickple.server.api.review.domain.Review;
+import com.pickple.server.global.exception.CustomException;
+import com.pickple.server.global.response.enums.ErrorCode;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findReviewById(Long id);
+
+    default Review findReviewByIdOrThrow(Long id) {
+        return findReviewById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+    }
 
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 

--- a/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
@@ -3,13 +3,11 @@ package com.pickple.server.api.review.repository;
 import com.pickple.server.api.review.domain.Review;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
-    @Query("SELECT r FROM Review r WHERE r.moim.id = :moimId")
-    List<Review> findReviewListByMoimId(Long moimId);
+    List<Review> findReviewListByMoimIdOrderByCreatedAt(Long moimId);
 
     List<Review> findReviewByMoimId(Long moimId);
 }

--- a/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickple/server/api/review/repository/ReviewRepository.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
     boolean existsByMoimIdAndGuestId(Long moimId, Long guestId);
 
     List<Review> findReviewListByMoimIdOrderByCreatedAt(Long moimId);
 
-    List<Review> findReviewByMoimId(Long moimId);
 }

--- a/src/main/java/com/pickple/server/api/user/repository/UserRepository.java
+++ b/src/main/java/com/pickple/server/api/user/repository/UserRepository.java
@@ -13,8 +13,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     @Query("SELECT u FROM User u WHERE u.socialId = :socialId AND u.socialType = :socialType")
-    Optional<User> findBySocialTypeAndSocialId(@Param("socialId") Long socialId,
-                                               @Param("socialType") SocialType socialType);
+    Optional<User> findUserBySocialTypeAndSocialId(@Param("socialId") Long socialId,
+                                                   @Param("socialType") SocialType socialType);
 
     Optional<User> findUserById(Long id);
 

--- a/src/main/java/com/pickple/server/api/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/pickple/server/api/user/repository/UserRepositoryCustom.java
@@ -5,5 +5,5 @@ import com.pickple.server.api.user.domain.User;
 import java.util.Optional;
 
 public interface UserRepositoryCustom {
-    Optional<User> findBySocialTypeAndSocialId(final Long socialId, final SocialType socialType);
+    Optional<User> findUserBySocialTypeAndSocialId(final Long socialId, final SocialType socialType);
 }

--- a/src/main/java/com/pickple/server/api/user/service/UserService.java
+++ b/src/main/java/com/pickple/server/api/user/service/UserService.java
@@ -91,7 +91,7 @@ public class UserService {
             final Long socialId,
             final SocialType socialType
     ) {
-        User user = userRepository.findBySocialTypeAndSocialId(socialId, socialType).orElseThrow(
+        User user = userRepository.findUserBySocialTypeAndSocialId(socialId, socialType).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
         return user;
@@ -171,7 +171,7 @@ public class UserService {
             final Long socialId,
             final SocialType socialType
     ) {
-        return userRepository.findBySocialTypeAndSocialId(socialId, socialType).isPresent();
+        return userRepository.findUserBySocialTypeAndSocialId(socialId, socialType).isPresent();
     }
 
     private boolean isExistingHost(final Long userId) {

--- a/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
+++ b/src/main/java/com/pickple/server/global/response/enums/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     SUBMITTER_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "호스트 승인 신청이 존재하지 않습니다."),
     NOTICE_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),
     COMMENT_NOT_FOUND(40410, HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    REVIEW_NOT_FOUND(40411, HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
 
     // 405 Method Not Allowed Error
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #249 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 리뷰 전체 조회 api 및 호스트에 해당하는 리뷰 전체 조회 api에 정렬을 추가했습니다
   <img width="876" alt="image" src="https://github.com/user-attachments/assets/5d6724df-1fd9-4efe-bc52-6884008ea844">

- repository 메소드명 컨벤션 적용했습니다
   -  repository 단복수 컨벤션을 상의 후 적용시켰습니다.
       단수일 경우
          MoimSubmissionRepository.findByMoimIdAndGuestId(moimId, guestId). - (x)
         moimSubmissionRepository.findMoimSubmissionByMoimIdAndGuestId(moimId, guestId) - (o)
      복수일 경우
         moimSubmissionRepository.findMoimSubmissionByMoimIdAndGuestId(moimId, guestId). - (x)
         moimSubmissionRepository.findMoimSubmissionListByMoimIdAndGuestId(moimId, guestId). - (x)
         moimSubmissionRepository.findMoimSubmissionsByMoimIdAndGuestId(moimId, guestId) - (o)

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 컨벤션을 앞으론 좀 더 신경써 보아요

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/a8b15494-f33c-4045-b359-a44418c4c261">
